### PR TITLE
Refactor magic fields and consolidate usage tracking

### DIFF
--- a/amrita/dirty.py
+++ b/amrita/dirty.py
@@ -246,9 +246,9 @@ class DirtyAwareModel(BaseModel):
         return value
 
     def _mark_dirty(self, name: str):
-        exclue: tuple[str, ...] | None
-        if exclue := getattr(self, "dirty_excluede__", None):
-            if name in exclue:
+        exclude: tuple[str, ...] | None
+        if exclude := getattr(self, "dirty_exclude__", None):
+            if name in exclude:
                 return
         dirty_vars: set[str] | None = getattr(self, "dirtyvars__", None)
         if dirty_vars is None:

--- a/amrita/plugins/chat/handlers/chat.py
+++ b/amrita/plugins/chat/handlers/chat.py
@@ -48,8 +48,10 @@ from pytz import utc
 from amrita.plugins.chat.config import ConfigManager, config_manager
 from amrita.plugins.chat.matcher import ChatException
 from amrita.plugins.chat.runtime import (
+    AMRITA_CTX_KEY,
     AmritaBotContext,
     bot_chat_manager,
+    get_amrita_ctx,
     pending_tasks,
 )
 from amrita.plugins.chat.runtime_session import SessionManager
@@ -57,13 +59,13 @@ from amrita.plugins.chat.utils.app import (
     AwaredMemory,
     CachedUserDataRepository,
     MemorySchema,
-    UserMetadataSchema,
 )
 from amrita.plugins.chat.utils.functions import (
     get_friend_name,
     split_message_into_chats,
     synthesize_message,
 )
+from amrita.plugins.chat.utils.libchat import add_usage
 from amrita.plugins.chat.utils.lock import get_group_lock, get_private_lock
 from amrita.plugins.chat.utils.sql import (
     InsightsModel,
@@ -109,24 +111,6 @@ def format_msg_xml(role: str, name: str, uid: str, content: str) -> str:
     safe_name = escape_xml(name)
     attrs = f' role="{role}"' if role else ""
     return f'<msg{attrs} name="{safe_name}" uid="{uid}">\n{safe_content}\n</msg>'
-
-
-def add_usage(
-    ins: InsightsModel | UserMetadataSchema, usage: UniResponseUsage[int] | None
-):
-    if isinstance(ins, InsightsModel):
-        if usage:
-            ins.token_output += usage.completion_tokens
-            ins.token_input += usage.prompt_tokens
-        ins.usage_count += 1
-    else:
-        if usage:
-            ins.tokens_input += usage.prompt_tokens
-            ins.tokens_output += usage.completion_tokens
-            ins.total_input_token += usage.prompt_tokens
-            ins.total_output_token += usage.completion_tokens
-        ins.called_count += 1
-        ins.total_called_count += 1
 
 
 async def handle_reply(
@@ -217,7 +201,7 @@ async def get_user_role(bot: Bot, group_id: int, user_id: int) -> str:
 
 async def send_response(chat: CoreChatObject, response: str):
     """发送聊天模型的回复，根据配置选择不同的发送方式。"""
-    ctx: AmritaBotContext = chat._hook_kwargs["amrita"]
+    ctx = get_amrita_ctx(chat)
     matcher = ctx["matcher"]
     bot_config = ctx["bot_config"]
     event = ctx["event"]
@@ -439,7 +423,6 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
     # ── 阶段 4：创建 ChatObject ─────────────────────────────────────
     ctx: AmritaBotContext = {
         "matcher": matcher,
-        "data": data,
         "memory": memory,
         "bot": bot,
         "event": event,
@@ -453,14 +436,14 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         auto_create_session=False,
         preset=PresetManager().get_preset(config.preset),
         hook_args=(event, matcher, bot),
-        hook_kwargs={"amrita": ctx},
+        hook_kwargs={AMRITA_CTX_KEY: ctx},
         exception_ignored=(ProcessException, MatcherException),
         agent_strategy=strategy,
         chat_man=bot_chat_manager,
     )
 
     # ── 阶段 5：设置回调并启动 ─────────────────────────────────────
-    async def filter(message: COMPLETION_RETURNING):
+    async def on_stream_message(message: COMPLETION_RETURNING):
         nonlocal can_send_message
         if isinstance(message, str):
             return
@@ -503,7 +486,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
             msg = MessageSegment.image(await message.get_image())
             await matcher.send(msg)
 
-    chat.set_callback_func(filter)
+    chat.set_callback_func(on_stream_message)
 
     lock = (
         get_group_lock(event.group_id) if is_group else get_private_lock(event.user_id)

--- a/amrita/plugins/chat/handlers/chatobj.py
+++ b/amrita/plugins/chat/handlers/chatobj.py
@@ -12,9 +12,9 @@ from nonebot.params import CommandArg
 from pytz import timezone, utc
 
 from amrita.plugins.chat.runtime import (
-    AmritaBotContext,
     bot_chat_manager,
     pending_tasks,
+    try_get_amrita_ctx,
 )
 from amrita.plugins.chat.utils.sql import get_uni_user_id
 from amrita.utils.send import send_forward_msg
@@ -66,9 +66,9 @@ def get_chat_objects_status(event: MessageEvent) -> dict[str, list[ChatObject]]:
 def format_chat_object_info(obj: ChatObject) -> str:
     """格式化单个ChatObject的信息。
 
-    通过 _hook_kwargs["amrita"] 读取 event 上下文。
+    通过 try_get_amrita_ctx 读取 event 上下文。
     """
-    ctx: AmritaBotContext | None = obj._hook_kwargs.get("amrita")
+    ctx = try_get_amrita_ctx(obj)
     if ctx is None:
         return f"\n🆔 ID: {obj.stream_id[:8]}...\n> 无上下文信息\n"
     event = ctx["event"]

--- a/amrita/plugins/chat/handlers/poke_event.py
+++ b/amrita/plugins/chat/handlers/poke_event.py
@@ -3,7 +3,7 @@ import random
 import sys
 import traceback
 
-from amrita_core import UniResponse, call_completion
+from amrita_core import UniResponse, UniResponseUsage, call_completion
 from amrita_core.types import Message as CoreMessage
 from nonebot import logger
 from nonebot.adapters.onebot.v11 import Bot, MessageSegment
@@ -20,7 +20,7 @@ from ..utils.functions import (
     get_friend_name,
     split_message_into_chats,
 )
-from ..utils.libchat import get_tokens, usage_enough
+from ..utils.libchat import add_usage, get_tokens, usage_enough
 from ..utils.lock import get_group_lock, get_private_lock
 from ..utils.sql import InsightsModel
 
@@ -36,7 +36,6 @@ async def poke_event(event: PokeNotifyEvent, bot: Bot, matcher: Matcher):
     if event.target_id != event.self_id:  # 如果目标不是机器人本身，直接返回
         return
     repo = CachedUserDataRepository()
-    data = await repo.get_memory(event.user_id, False)
 
     try:
         fake_event = FakeEvent(
@@ -50,10 +49,10 @@ async def poke_event(event: PokeNotifyEvent, bot: Bot, matcher: Matcher):
 
         if event.group_id is not None:  # 判断是群聊还是私聊
             async with get_group_lock(event.group_id):
-                await handle_group_poke(event, bot, matcher, repo, data)
+                await handle_group_poke(event, bot, matcher, repo)
         else:
             async with get_private_lock(event.user_id):
-                await handle_private_poke(event, bot, matcher, repo, data)
+                await handle_private_poke(event, bot, matcher, repo)
     except NoneBotException:
         raise
     except Exception:
@@ -65,7 +64,6 @@ async def handle_group_poke(
     bot: Bot,
     matcher: Matcher,
     repo: CachedUserDataRepository,
-    data,
 ):
     """处理群聊中的戳一戳事件"""
     assert event.group_id is not None
@@ -99,7 +97,7 @@ async def handle_group_poke(
             content=f"<戳一戳消息>{user_name} (QQ:{event.user_id}) 戳了戳你",
         ),
     ]
-    response = await process_poke_event(event, send_messages, repo, data)
+    response = await process_poke_event(event, send_messages, repo)
     message = (
         MessageSegment.at(user_id=event.user_id)
         + MessageSegment.text(" ")
@@ -118,16 +116,19 @@ async def handle_private_poke(
     bot: Bot,
     matcher: Matcher,
     repo: CachedUserDataRepository,
-    data,
 ):
     """处理私聊中的戳一戳事件"""
     # 检查使用限制
     if (
         config_manager.config.usage_limit.enable_usage_limit
         and config_manager.config.usage_limit.user_daily_limit != -1
-        and data.usage >= config_manager.config.usage_limit.user_daily_limit
     ):
-        await matcher.finish()
+        user_meta = await repo.get_metadata(event.user_id, False)
+        if (
+            user_meta.called_count
+            >= config_manager.config.usage_limit.user_daily_limit
+        ):
+            await matcher.finish()
 
     name = await get_friend_name(event.user_id, bot)  # 获取好友信息
     send_messages = [
@@ -139,7 +140,7 @@ async def handle_private_poke(
     ]
 
     # 处理戳一戳事件并获取回复
-    response = await process_poke_event(event, send_messages, repo, data)
+    response = await process_poke_event(event, send_messages, repo)
     if not config_manager.config.function.nature_chat_style:
         await matcher.send(MessageSegment.text(response))
     else:
@@ -147,7 +148,9 @@ async def handle_private_poke(
 
 
 async def process_poke_event(
-    event: PokeNotifyEvent, send_messages: list, repo: CachedUserDataRepository, data
+    event: PokeNotifyEvent,
+    send_messages: list,
+    repo: CachedUserDataRepository,
 ) -> str:
     """处理戳一戳事件的核心逻辑"""
     # 直接调用completion API来处理消息
@@ -170,20 +173,17 @@ async def process_poke_event(
     output_tokens = (
         tokens.completion_tokens if hasattr(tokens, "completion_tokens") else 0
     )
+    usage = UniResponseUsage(
+        prompt_tokens=input_tokens,
+        completion_tokens=output_tokens,
+        total_tokens=input_tokens + output_tokens,
+    )
+
     insights = await InsightsModel.get()
+    add_usage(insights, usage)
 
-    insights.usage_count += 1
-    insights.token_output += output_tokens
-    insights.token_input += input_tokens
-
-    # 更新用户数据使用情况
     user_meta = await repo.get_metadata(event.user_id, False)
-    user_meta.called_count += 1
-    user_meta.tokens_input += input_tokens
-    user_meta.tokens_output += output_tokens
-    user_meta.total_called_count += 1
-    user_meta.total_input_token += input_tokens
-    user_meta.total_output_token += output_tokens
+    add_usage(user_meta, usage)
     await repo.update_metadata(user_meta)
 
     # 保存insights

--- a/amrita/plugins/chat/runtime.py
+++ b/amrita/plugins/chat/runtime.py
@@ -12,31 +12,39 @@ from collections import defaultdict
 from typing import TypedDict
 
 from amrita_core.chatmanager import ChatManager
+from amrita_core.chatmanager import ChatObject as CoreChatObject
 from nonebot.adapters.onebot.v11 import Bot
 from nonebot.adapters.onebot.v11.event import MessageEvent
 from nonebot.matcher import Matcher
 
 from amrita.plugins.chat.config import Config
-from amrita.plugins.chat.utils.app import (
-    AwaredMemory,
-    MemorySchema,
-)
+from amrita.plugins.chat.utils.app import MemorySchema
+
+# hook_kwargs 中存放上下文的键
+AMRITA_CTX_KEY = "amrita"
 
 
 class AmritaBotContext(TypedDict):
-    """
-    通过 ChatObject._hook_kwargs["amrita"] 传递的上下文。
-
-    handler 在创建 ChatObject 时填充此字典，
-    chatobj.py 等管理模块通过 _hook_kwargs 读取。
-    """
+    """跨 handler 共享的上下文，消息体走 memory.memory_json"""
 
     matcher: Matcher
-    data: AwaredMemory
     memory: MemorySchema
     bot: Bot
     event: MessageEvent
     bot_config: Config
+
+
+def try_get_amrita_ctx(obj: CoreChatObject) -> AmritaBotContext | None:
+    """读取上下文，没有则 None"""
+    return obj._hook_kwargs.get(AMRITA_CTX_KEY)
+
+
+def get_amrita_ctx(obj: CoreChatObject) -> AmritaBotContext:
+    """读取上下文，没有则报错"""
+    ctx = try_get_amrita_ctx(obj)
+    if ctx is None:
+        raise RuntimeError("缺少 AmritaBotContext")
+    return ctx
 
 
 bot_chat_manager = ChatManager()

--- a/amrita/plugins/chat/utils/app.py
+++ b/amrita/plugins/chat/utils/app.py
@@ -21,7 +21,7 @@ class BaseSchema(BaseModel):
     Base Schema
     """
 
-    dirty_excluede__: tuple = Field(
+    dirty_exclude__: tuple = Field(
         ("id", "user_id", "model_config"), exclude=True, init=False
     )
 

--- a/amrita/plugins/chat/utils/libchat.py
+++ b/amrita/plugins/chat/utils/libchat.py
@@ -1,4 +1,4 @@
-from amrita_core import call_completion
+from amrita_core import UniResponseUsage, call_completion
 from amrita_core.libchat import (
     _call_with_reflection,
     _validate_msg_list,
@@ -15,6 +15,25 @@ from amrita.plugins.chat.utils.sql import InsightsModel
 from amrita.plugins.perm.API.rules import any_has_permission
 
 is_bot_admin = None
+
+
+def add_usage(
+    ins: InsightsModel | UserMetadataSchema, usage: UniResponseUsage[int] | None
+) -> None:
+    """累加 token 用量"""
+    if isinstance(ins, InsightsModel):
+        if usage:
+            ins.token_output += usage.completion_tokens
+            ins.token_input += usage.prompt_tokens
+        ins.usage_count += 1
+    else:
+        if usage:
+            ins.tokens_input += usage.prompt_tokens
+            ins.tokens_output += usage.completion_tokens
+            ins.total_input_token += usage.prompt_tokens
+            ins.total_output_token += usage.completion_tokens
+        ins.called_count += 1
+        ins.total_called_count += 1
 
 
 async def usage_enough(event: Event) -> bool:
@@ -91,6 +110,7 @@ async def usage_enough(event: Event) -> bool:
 __all__ = [
     "_call_with_reflection",
     "_validate_msg_list",
+    "add_usage",
     "call_completion",
     "get_last_response",
     "get_tokens",


### PR DESCRIPTION
- 消除 _hook_kwargs["amrita"] 魔法字符串访问，改为常量和辅助函数。
- 清理冗余字段
- add_usage 提取到 libchat.py 供 chat/poke 共用
- 修复 poke 路径漏更新长期统计字段及 data.usage 属性不存在问题
- 顺带修正 dirty_excluede__ 拼写错误，重命名遮蔽内置的局部函数 filter

## Summary by Sourcery

重构聊天运行时上下文处理和使用情况追踪，整合 Token 计费逻辑并修复脏字段配置中的拼写错误。

Bug 修复：
- 修正对 poke 事件的使用上限限制，通过从用户元数据中读取调用次数，而不是使用内存中的数据对象。
- 确保 poke 事件处理能够一致地更新全局洞察数据和按用户划分的长期使用统计。
- 修复脏跟踪配置属性中的拼写错误，使被排除的字段不再被错误地标记为脏。

增强改进：
- 为在 ChatObject 实例上访问共享的 `AmritaBotContext` 引入具名常量和辅助函数，替代直接使用底层的魔法键 `_hook_kwargs`。
- 通过将 Token 使用量累积逻辑集中到 `libchat.py` 中共享的 `add_usage` 辅助函数中，简化 chat 和 poke 处理器。
- 精简 `AmritaBotContext` 仅保存基于记忆的状态，并将流式回调重命名为更能体现意图的名称。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Refactor chat runtime context handling and usage tracking, consolidating token accounting logic and fixing dirty-field configuration typos.

Bug Fixes:
- Correct usage-limit enforcement for poke events by reading call counts from user metadata instead of in-memory data objects.
- Ensure poke event handling updates both global insights and per-user long-term usage statistics consistently.
- Fix typo in dirty-tracking configuration attribute so excluded fields are no longer incorrectly marked dirty.

Enhancements:
- Introduce a named constant and helper functions for accessing the shared AmritaBotContext on ChatObject instances instead of using the raw magic _hook_kwargs key.
- Simplify chat and poke handlers by centralizing token usage accumulation into a shared add_usage helper in libchat.py.
- Streamline AmritaBotContext to only carry memory-based state and rename the streaming callback to an intent-revealing name.

</details>