### PR TITLE
Split ConfigManager into PromptStore and PresetStore

### DIFF
--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -1,17 +1,15 @@
 import json
 import os
 import re
-from copy import deepcopy
-from dataclasses import dataclass, field
+from functools import lru_cache
 from pathlib import Path
 from typing import Any, ClassVar, Literal
 
-import aiofiles
 import nonebot_plugin_localstore as store
 import tomli
 import tomli_w
 from amrita_core import ModelPreset as ModelPreset
-from amrita_core import PresetManager, set_config
+from amrita_core import set_config
 from amrita_core.config import (
     AmritaConfig as AmritaCoreConfig,
 )
@@ -19,24 +17,25 @@ from amrita_core.config import (
     LLMConfig as CoreLLMConfig,
 )
 from nonebot import get_driver, logger
-from nonebot_plugin_uniconf import EnvfulConfigManager
-from nonebot_plugin_uniconf.manager import replace_env_vars
+from nonebot_plugin_uniconf import EnvfulConfigManager, UniConfigManager
 from pydantic import BaseModel, Field, model_validator
 from typing_extensions import final, override
 
-from amrita.config_manager import UniConfigManager
+from .preset_store import PresetStore
+from .prompt_store import Prompt as Prompt
+from .prompt_store import Prompts, PromptStore
 
 __kernel_version__ = "unknown"
-
-# 保留为其他插件提供的引用
 
 # 配置目录
 CONFIG_DIR: Path = store.get_plugin_config_dir()
 driver = get_driver()
 nb_config = driver.config
-# 缓存的正则表达式
-_re_hash: int = 0
-_cached_pattern: re.Pattern[str] | None = None
+
+
+@lru_cache(maxsize=8)
+def _compile_pattern(pattern: str) -> re.Pattern[str]:
+    return re.compile(pattern)
 
 
 class ToolsConfig(BaseModel):
@@ -128,12 +127,7 @@ class FunctionConfig(BaseModel):
         """
         获取分句的正则表达式
         """
-        global _cached_pattern, _re_hash
-        pattern_hash = hash(self.nature_chat_cut_pattern)
-        if pattern_hash != _re_hash or _cached_pattern is None:
-            _cached_pattern = re.compile(self.nature_chat_cut_pattern)
-            _re_hash = pattern_hash
-        return _cached_pattern
+        return _compile_pattern(self.nature_chat_cut_pattern)
 
 
 class PresetSwitch(BaseModel):
@@ -373,49 +367,15 @@ class Config(BaseModel):
         return super().model_dump(**kwargs)
 
 
-@dataclass
-class Prompt:
-    text: str = ""
-    name: str = "default"
-
-
-@dataclass
-class Prompts:
-    group: list[Prompt] = field(default_factory=list)
-    private: list[Prompt] = field(default_factory=list)
-
-    def save_group(self, path: Path):
-        """保存群组提示词"""
-        for prompt in self.group:
-            with (path / f"{prompt.name}.txt").open(
-                "w",
-                encoding="u8",
-            ) as f:
-                f.write(prompt.text)
-
-    def save_private(self, path: Path):
-        """保存私聊提示词"""
-        for prompt in self.private:
-            with (path / f"{prompt.name}.txt").open(
-                "w",
-                encoding="u8",
-            ) as f:
-                f.write(prompt.text)
-
-
 @final
 class ConfigManager(EnvfulConfigManager[Config]):
     config_dir: Path = CONFIG_DIR
     private_prompts: Path = config_dir / "private_prompts"
     group_prompts: Path = config_dir / "group_prompts"
     custom_models_dir: Path = config_dir / "models"
-    _private_train: ClassVar[dict[str, Any]] = {}
-    _group_train: ClassVar[dict[str, Any]] = {}
-    _model_name2file: ClassVar[dict[str, Path]] = {}
-    models: ClassVar[list[tuple[ModelPreset, str]]] = []
-    prompts: Prompts = Prompts()
+    prompt_store: ClassVar[PromptStore] = PromptStore(private_prompts, group_prompts)
+    preset_store: ClassVar[PresetStore] = PresetStore(custom_models_dir)
     config: Config
-    _owner_name = store._try_get_caller_plugin().name
     __lateinit__ = True
 
     @override
@@ -471,37 +431,39 @@ class ConfigManager(EnvfulConfigManager[Config]):
             ),
         )
 
-    def validate_presets(self):
-        def validate_preset(path: Path):
-            try:
-                model_data = ModelPreset.load(path)
-                model_data.save(path)
-                self._model_name2file[model_data.name] = path
-            except Exception as e:
-                logger.opt(colors=True).error(
-                    f"Failed to validate preset '{file!s}' because '{e!s}'"
-                )
+    @property
+    def prompts(self) -> Prompts:
+        return self.prompt_store.prompts
 
-        for file in self.custom_models_dir.glob("*.json"):
-            validate_preset(file)
+    async def get_prompts(
+        self, cache: bool = False, load_only: bool = False
+    ) -> Prompts:
+        """获取提示词"""
+        return await self.prompt_store.load(cache=cache, load_only=load_only)
+
+    async def load_prompt(self):
+        """加载提示词，匹配预设"""
+        self.prompt_store.apply(
+            self.ins_config.group_prompt_character,
+            self.ins_config.private_prompt_character,
+        )
+
+    @property
+    def private_train(self) -> dict[str, str]:
+        """获取私聊提示词"""
+        return self.prompt_store.private_train
+
+    @property
+    def group_train(self) -> dict[str, str]:
+        """获取群聊提示词"""
+        return self.prompt_store.group_train
+
+    def validate_presets(self):
+        self.preset_store.validate()
 
     async def get_all_presets(self, cache: bool = False) -> list[ModelPreset]:
         """获取模型列表"""
-        if cache and self.models:
-            return [model for model, _ in self.models]
-        self.models.clear()  # 清空模型列表
-        PresetManager()._presets.clear()
-        for file in self.custom_models_dir.glob("*.json"):
-            model_data = ModelPreset.load(file).model_dump()
-            preset_data = replace_env_vars(model_data)
-            if not isinstance(preset_data, dict):
-                raise TypeError("Expected replace_env_vars to return a dict")
-            model_preset = ModelPreset.model_validate(preset_data)
-            self._model_name2file[model_preset.name] = file
-            self.models.append((model_preset, file.stem))
-            PresetManager().add_preset(model_preset)
-
-        return [model for model, _ in self.models]
+        return await self.preset_store.load_all(cache=cache)
 
     async def get_preset(
         self, preset: str, fix: bool = False, cache: bool = False
@@ -518,84 +480,20 @@ class ConfigManager(EnvfulConfigManager[Config]):
         """
         if preset == "default":
             return self.config.default_preset
-        for model in await self.get_all_presets(cache=cache):
-            if model.name == preset:
-                return model
+        if (model := await self.preset_store.find(preset, cache=cache)) is not None:
+            return model
         if fix:
             self.ins_config.preset = "default"
             await self.save_config()
         return await self.get_preset("default", fix, cache)
 
-    async def get_prompts(
-        self, cache: bool = False, load_only: bool = False
-    ) -> Prompts:
-        """获取提示词"""
-        if cache and self.prompts:
-            return self.prompts
-        self.prompts = Prompts()
-        for file in self.private_prompts.glob("*.txt"):
-            async with aiofiles.open(file, encoding="utf-8") as f:
-                prompt = await f.read()
-            self.prompts.private.append(Prompt(prompt, file.stem))
-        for file in self.group_prompts.glob("*.txt"):
-            async with aiofiles.open(file, encoding="utf-8") as f:
-                prompt = await f.read()
-            self.prompts.group.append(Prompt(prompt, file.stem))
-        if not self.prompts.private:
-            self.prompts.private.append(Prompt("", "default"))
-        if not self.prompts.group:
-            self.prompts.group.append(Prompt("", "default"))
+    def get_preset_path(self, name: str) -> Path:
+        """预设名对应的文件路径"""
+        return self.preset_store.path_of(name)
 
-        if not load_only:
-            self.prompts.save_private(self.private_prompts)
-            self.prompts.save_group(self.group_prompts)
-
-        return self.prompts
-
-    @property
-    def private_train(self) -> dict[str, str]:
-        """获取私聊提示词"""
-        return deepcopy(self._private_train)
-
-    @property
-    def group_train(self) -> dict[str, str]:
-        """获取群聊提示词"""
-        return deepcopy(self._group_train)
-
-    async def load_prompt(self):
-        """加载提示词，匹配预设"""
-        for prompt in self.prompts.group:
-            if prompt.name == self.ins_config.group_prompt_character:
-                self.__class__._group_train = {"role": "system", "content": prompt.text}
-                break
-        else:
-            self.__class__._group_train = {
-                "role": "system",
-                "content": next(
-                    i for i in self.prompts.group if i.name == "default"
-                ).text,
-            }
-            logger.warning(
-                f"没有找到名称为 {self.ins_config.group_prompt_character} 的群组提示词，将使用default.txt!"
-            )
-
-        for prompt in self.prompts.private:
-            if prompt.name == self.ins_config.private_prompt_character:
-                self.__class__._private_train = {
-                    "role": "system",
-                    "content": prompt.text,
-                }
-                break
-        else:
-            logger.warning(
-                f"没有找到名称为 {self.ins_config.private_prompt_character} 的私聊提示词，将使用default.txt！"
-            )
-            self.__class__._private_train = {
-                "role": "system",
-                "content": next(
-                    i for i in self.prompts.private if i.name == "default"
-                ).text,
-            }
+    def forget_preset(self, name: str) -> None:
+        """移除预设名到路径的记录"""
+        self.preset_store.forget(name)
 
     async def save_config(self):
         """保存配置"""
@@ -628,14 +526,14 @@ class ConfigManager(EnvfulConfigManager[Config]):
         self.ins_config.extra.setdefault(key, default_value)
         await self.save_config()
 
-    def reg_config(self, key: str, default_value=None):
+    async def reg_config(self, key: str, default_value=None):
         """
         注册配置项
 
         :param key: 配置项的名称
 
         """
-        return self.register_config(key, default_value)
+        return await self.register_config(key, default_value)
 
     def reg_model_config(self, key: str, default_value=None):
         """
@@ -648,9 +546,7 @@ class ConfigManager(EnvfulConfigManager[Config]):
             default_value = "null"
         if key not in self.ins_config.default_preset.extra:
             self.ins_config.default_preset.extra.setdefault(key, default_value)
-        for model, name in self.models:
-            model.extra.setdefault(key, default_value)
-            model.save(self.custom_models_dir / f"{name}.json")
+        self.preset_store.register_extra(key, default_value)
 
 
 config_manager = ConfigManager()

--- a/amrita/plugins/chat/page.py
+++ b/amrita/plugins/chat/page.py
@@ -113,7 +113,7 @@ async def update_model(request: Request, name: str):
                 setattr(preset, key, value)
 
         # 保存模型预设到文件
-        preset_path = config_manager._model_name2file[name]
+        preset_path = config_manager.get_preset_path(name)
 
         preset.save(preset_path)
 
@@ -134,7 +134,7 @@ async def update_model(request: Request, name: str):
 @router.delete("/api/chat/models/{name}")
 async def delete_model(name: str):
     try:
-        preset_path = config_manager._model_name2file[name]
+        preset_path = config_manager.get_preset_path(name)
 
         if not preset_path.exists():
             return JSONResponse(
@@ -145,7 +145,7 @@ async def delete_model(name: str):
 
         # 重新加载模型列表
         await config_manager.get_all_presets(cache=False)
-        del config_manager._model_name2file[name]
+        config_manager.forget_preset(name)
 
         return JSONResponse(
             {"success": True, "message": f"模型预设 {name} 删除成功"}, status_code=200

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -24,7 +24,7 @@ class PresetStore:
     def __init__(self, models_dir: Path):
         self.models_dir = models_dir
         self._loaded: list[LoadedPreset] = []
-        self._by_name: dict[str, Path] = {}
+        self._by_name: dict[str, LoadedPreset] = {}
 
     def validate(self) -> None:
         """校验目录下所有预设文件"""
@@ -32,7 +32,9 @@ class PresetStore:
             try:
                 model_data = ModelPreset.load(path)
                 model_data.save(path)
-                self._by_name[model_data.name] = path
+                self._by_name[model_data.name] = LoadedPreset(
+                    model_data, path.stem, path
+                )
             except Exception as e:
                 logger.opt(colors=True).error(
                     f"Failed to validate preset '{path!s}' because '{e!s}'"
@@ -43,6 +45,7 @@ class PresetStore:
         if cache and self._loaded:
             return [lp.preset for lp in self._loaded]
         self._loaded.clear()
+        self._by_name.clear()
         PresetManager()._presets.clear()
         for path in self.models_dir.glob("*.json"):
             model_data = ModelPreset.load(path).model_dump()
@@ -50,25 +53,25 @@ class PresetStore:
             if not isinstance(preset_data, dict):
                 raise TypeError("Expected replace_env_vars to return a dict")
             model_preset = ModelPreset.model_validate(preset_data)
-            self._by_name[model_preset.name] = path
-            self._loaded.append(LoadedPreset(model_preset, path.stem, path))
+            lp = LoadedPreset(model_preset, path.stem, path)
+            self._by_name[model_preset.name] = lp
+            self._loaded.append(lp)
             PresetManager().add_preset(model_preset)
         return [lp.preset for lp in self._loaded]
 
     async def find(self, name: str, *, cache: bool = False) -> ModelPreset | None:
         """按名查找预设"""
-        for preset in await self.load_all(cache=cache):
-            if preset.name == name:
-                return preset
-        return None
+        await self.load_all(cache=cache)
+        lp = self._by_name.get(name)
+        return lp.preset if lp else None
 
     def path_of(self, name: str) -> Path:
         """预设名对应的文件路径"""
-        return self._by_name[name]
+        return self._by_name[name].path
 
     def forget(self, name: str) -> None:
         """移除预设名到路径的记录"""
-        del self._by_name[name]
+        self._by_name.pop(name, None)
 
     def register_extra(self, key: str, default_value: Any) -> None:
         """给所有预设补默认 extra 字段并存盘"""

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -1,0 +1,77 @@
+"""模型预设存储"""
+
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from typing import Any
+
+from amrita_core import ModelPreset, PresetManager
+from nonebot import logger
+from nonebot_plugin_uniconf.manager import replace_env_vars
+
+
+@dataclass
+class LoadedPreset:
+    preset: ModelPreset
+    stem: str
+    path: Path
+
+
+class PresetStore:
+    """模型预设的发现、校验与缓存"""
+
+    def __init__(self, models_dir: Path):
+        self.models_dir = models_dir
+        self._loaded: list[LoadedPreset] = []
+        self._by_name: dict[str, Path] = {}
+
+    def validate(self) -> None:
+        """校验目录下所有预设文件"""
+        for path in self.models_dir.glob("*.json"):
+            try:
+                model_data = ModelPreset.load(path)
+                model_data.save(path)
+                self._by_name[model_data.name] = path
+            except Exception as e:
+                logger.opt(colors=True).error(
+                    f"Failed to validate preset '{path!s}' because '{e!s}'"
+                )
+
+    async def load_all(self, *, cache: bool = False) -> list[ModelPreset]:
+        """加载全部预设并注册到 PresetManager"""
+        if cache and self._loaded:
+            return [lp.preset for lp in self._loaded]
+        self._loaded.clear()
+        PresetManager()._presets.clear()
+        for path in self.models_dir.glob("*.json"):
+            model_data = ModelPreset.load(path).model_dump()
+            preset_data = replace_env_vars(model_data)
+            if not isinstance(preset_data, dict):
+                raise TypeError("Expected replace_env_vars to return a dict")
+            model_preset = ModelPreset.model_validate(preset_data)
+            self._by_name[model_preset.name] = path
+            self._loaded.append(LoadedPreset(model_preset, path.stem, path))
+            PresetManager().add_preset(model_preset)
+        return [lp.preset for lp in self._loaded]
+
+    async def find(self, name: str, *, cache: bool = False) -> ModelPreset | None:
+        """按名查找预设"""
+        for preset in await self.load_all(cache=cache):
+            if preset.name == name:
+                return preset
+        return None
+
+    def path_of(self, name: str) -> Path:
+        """预设名对应的文件路径"""
+        return self._by_name[name]
+
+    def forget(self, name: str) -> None:
+        """移除预设名到路径的记录"""
+        del self._by_name[name]
+
+    def register_extra(self, key: str, default_value: Any) -> None:
+        """给所有预设补默认 extra 字段并存盘"""
+        for lp in self._loaded:
+            lp.preset.extra.setdefault(key, default_value)
+            lp.preset.save(lp.path)

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -35,7 +35,7 @@ class PresetStore:
                 self._by_name[model_data.name] = LoadedPreset(
                     model_data, path.stem, path
                 )
-            except Exception as e:
+            except Exception as e:  # noqa: PERF203
                 logger.opt(colors=True).error(
                     f"Failed to validate preset '{path!s}' because '{e!s}'"
                 )

--- a/amrita/plugins/chat/prompt_store.py
+++ b/amrita/plugins/chat/prompt_store.py
@@ -72,14 +72,18 @@ class PromptStore:
         for prompt in prompts:
             if prompt.name == character:
                 return {"role": "system", "content": prompt.text}
-        logger.warning(f"没有找到名称为 {character} 的{label}提示词，将使用default.txt!")
+        logger.warning(
+            f"没有找到名称为 {character} 的{label}提示词，将使用default.txt!"
+        )
         fallback = next((p for p in prompts if p.name == "default"), None)
         return {"role": "system", "content": fallback.text if fallback else ""}
 
     def apply(self, group_character: str, private_character: str) -> None:
         """按预设名匹配当前提示词"""
         self._group_train = self._pick(self.prompts.group, group_character, "群组")
-        self._private_train = self._pick(self.prompts.private, private_character, "私聊")
+        self._private_train = self._pick(
+            self.prompts.private, private_character, "私聊"
+        )
 
     @property
     def private_train(self) -> dict[str, str]:

--- a/amrita/plugins/chat/prompt_store.py
+++ b/amrita/plugins/chat/prompt_store.py
@@ -1,0 +1,108 @@
+"""提示词存储"""
+
+from __future__ import annotations
+
+from copy import deepcopy
+from dataclasses import dataclass, field
+from pathlib import Path
+from typing import Any
+
+import aiofiles
+from nonebot import logger
+
+
+@dataclass
+class Prompt:
+    text: str = ""
+    name: str = "default"
+
+
+@dataclass
+class Prompts:
+    group: list[Prompt] = field(default_factory=list)
+    private: list[Prompt] = field(default_factory=list)
+
+    def save_group(self, path: Path):
+        """保存群组提示词"""
+        for prompt in self.group:
+            with (path / f"{prompt.name}.txt").open("w", encoding="u8") as f:
+                f.write(prompt.text)
+
+    def save_private(self, path: Path):
+        """保存私聊提示词"""
+        for prompt in self.private:
+            with (path / f"{prompt.name}.txt").open("w", encoding="u8") as f:
+                f.write(prompt.text)
+
+
+class PromptStore:
+    """提示词加载与匹配"""
+
+    def __init__(self, private_dir: Path, group_dir: Path):
+        self.private_dir = private_dir
+        self.group_dir = group_dir
+        self.prompts = Prompts()
+        self._private_train: dict[str, Any] = {}
+        self._group_train: dict[str, Any] = {}
+
+    async def load(self, *, cache: bool = False, load_only: bool = False) -> Prompts:
+        """加载提示词文件"""
+        if cache and self.prompts:
+            return self.prompts
+        self.prompts = Prompts()
+        for file in self.private_dir.glob("*.txt"):
+            async with aiofiles.open(file, encoding="utf-8") as f:
+                text = await f.read()
+            self.prompts.private.append(Prompt(text, file.stem))
+        for file in self.group_dir.glob("*.txt"):
+            async with aiofiles.open(file, encoding="utf-8") as f:
+                text = await f.read()
+            self.prompts.group.append(Prompt(text, file.stem))
+        if not self.prompts.private:
+            self.prompts.private.append(Prompt("", "default"))
+        if not self.prompts.group:
+            self.prompts.group.append(Prompt("", "default"))
+        if not load_only:
+            self.prompts.save_private(self.private_dir)
+            self.prompts.save_group(self.group_dir)
+        return self.prompts
+
+    def apply(self, group_character: str, private_character: str) -> None:
+        """按预设名匹配当前提示词"""
+        for prompt in self.prompts.group:
+            if prompt.name == group_character:
+                self._group_train = {"role": "system", "content": prompt.text}
+                break
+        else:
+            self._group_train = {
+                "role": "system",
+                "content": next(
+                    i for i in self.prompts.group if i.name == "default"
+                ).text,
+            }
+            logger.warning(f"没有找到名称为 {group_character} 的群组提示词，将使用default.txt!")
+
+        for prompt in self.prompts.private:
+            if prompt.name == private_character:
+                self._private_train = {"role": "system", "content": prompt.text}
+                break
+        else:
+            logger.warning(
+                f"没有找到名称为 {private_character} 的私聊提示词，将使用default.txt！"
+            )
+            self._private_train = {
+                "role": "system",
+                "content": next(
+                    i for i in self.prompts.private if i.name == "default"
+                ).text,
+            }
+
+    @property
+    def private_train(self) -> dict[str, str]:
+        """获取私聊提示词"""
+        return deepcopy(self._private_train)
+
+    @property
+    def group_train(self) -> dict[str, str]:
+        """获取群聊提示词"""
+        return deepcopy(self._group_train)

--- a/amrita/plugins/chat/prompt_store.py
+++ b/amrita/plugins/chat/prompt_store.py
@@ -47,7 +47,7 @@ class PromptStore:
 
     async def load(self, *, cache: bool = False, load_only: bool = False) -> Prompts:
         """加载提示词文件"""
-        if cache and self.prompts:
+        if cache and (self.prompts.group or self.prompts.private):
             return self.prompts
         self.prompts = Prompts()
         for file in self.private_dir.glob("*.txt"):
@@ -67,35 +67,19 @@ class PromptStore:
             self.prompts.save_group(self.group_dir)
         return self.prompts
 
+    @staticmethod
+    def _pick(prompts: list[Prompt], character: str, label: str) -> dict[str, Any]:
+        for prompt in prompts:
+            if prompt.name == character:
+                return {"role": "system", "content": prompt.text}
+        logger.warning(f"没有找到名称为 {character} 的{label}提示词，将使用default.txt!")
+        fallback = next((p for p in prompts if p.name == "default"), None)
+        return {"role": "system", "content": fallback.text if fallback else ""}
+
     def apply(self, group_character: str, private_character: str) -> None:
         """按预设名匹配当前提示词"""
-        for prompt in self.prompts.group:
-            if prompt.name == group_character:
-                self._group_train = {"role": "system", "content": prompt.text}
-                break
-        else:
-            self._group_train = {
-                "role": "system",
-                "content": next(
-                    i for i in self.prompts.group if i.name == "default"
-                ).text,
-            }
-            logger.warning(f"没有找到名称为 {group_character} 的群组提示词，将使用default.txt!")
-
-        for prompt in self.prompts.private:
-            if prompt.name == private_character:
-                self._private_train = {"role": "system", "content": prompt.text}
-                break
-        else:
-            logger.warning(
-                f"没有找到名称为 {private_character} 的私聊提示词，将使用default.txt！"
-            )
-            self._private_train = {
-                "role": "system",
-                "content": next(
-                    i for i in self.prompts.private if i.name == "default"
-                ).text,
-            }
+        self._group_train = self._pick(self.prompts.group, group_character, "群组")
+        self._private_train = self._pick(self.prompts.private, private_character, "私聊")
 
     @property
     def private_train(self) -> dict[str, str]:


### PR DESCRIPTION
- ConfigManager 拆成三块：提示词 PromptStore，模型预设 PresetStore，ConfigManager 负责组合与读写配置                                                                                                                                                                                              
- reg_config 漏了 await
- 不导入 UniConfigManager
- 模型列表的 (预设, 文件名) 裸元组换成有名字的 LoadedPreset
- 去掉类定义里调私有 API 取插件名的写法
- 分句正则的缓存改用 lru_cache
- page.py 中 _model_name2file 改走方法获取

## Summary by Sourcery

将聊天配置职责拆分为专门的提示（prompt）和预设（preset）存储组件，并相应调整使用它们的调用方。

新功能：
- 引入 `PromptStore` 和 `PresetStore` 抽象，分别用于管理提示文件和模型预设。

错误修复：
- 将 `reg_config` 改为异步函数，并确保其内部的 `register_config` 调用被正确等待（await）。
- 修复预设校验日志，让其在报告错误时引用正确的文件路径。

改进：
- 重构 `ConfigManager`，将提示加载/匹配以及模型预设的发现、缓存和额外字段注册等职责委托给新的存储组件。
- 用基于 `lru_cache` 的辅助函数替换用于句子分割的手动正则缓存逻辑。
- 通过 `ConfigManager` 方法对外暴露预设路径查询和“忘记”功能，而不是依赖其内部映射。
- 将模型预设跟踪方式从原始元组切换为名为 `LoadedPreset` 的结构体，以实现更清晰的数据处理。

<details>
<summary>Original summary in English</summary>

## Summary by Sourcery

Split chat configuration responsibilities into dedicated prompt and preset storage components and adjust consumers accordingly.

New Features:
- Introduce PromptStore and PresetStore abstractions for managing prompt files and model presets, respectively.

Bug Fixes:
- Make reg_config asynchronous and ensure its internal register_config call is awaited.
- Fix preset validation logging to reference the correct file path when reporting errors.

Enhancements:
- Refactor ConfigManager to delegate prompt loading/matching and model preset discovery, caching, and extra-field registration to the new stores.
- Replace manual regex caching logic for sentence splitting with an lru_cache-based helper.
- Expose preset path lookup and forgetting via ConfigManager methods instead of relying on internal maps.
- Switch model preset tracking from raw tuples to a named LoadedPreset structure for clearer data handling.

</details>