### PR TITLE
Allow chat core to use default session by omitting session ID

### DIFF
--- a/amrita/plugins/chat/handlers/chat.py
+++ b/amrita/plugins/chat/handlers/chat.py
@@ -443,7 +443,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         train=train_dict,
         user_input=content,
         context=core_ctx,
-        session_id=session_id,
+        session_id=None,
         preset=await ConfigManager().get_preset(config.preset),
         hook_args=(event, matcher, bot),
         hook_kwargs={AMRITA_CTX_KEY: ctx},

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.3.0"
+version = "1.3.1"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
## Summary by Sourcery

Disable chat handler session scoping and bump the project version.

Enhancements:
- Stop passing a specific session identifier into the chat handler, effectively disabling per-session scoping for that call.

Build:
- Bump project version from 1.3.0 to 1.3.1 in pyproject configuration.