### PR TITLE
fix(chat): handle unknown category in get_amrita_info and bump version

### DIFF
--- a/amrita/plugins/chat/utils/llm_tools/builtin_tools.py
+++ b/amrita/plugins/chat/utils/llm_tools/builtin_tools.py
@@ -1,5 +1,4 @@
 from copy import deepcopy
-from typing import Literal
 
 from amrita_core import PreCompletionEvent, simple_tool
 from amrita_core.tools.models import (
@@ -135,11 +134,11 @@ REPORT_TOOL_LOW = ToolFunctionSchema(
 
 
 @simple_tool
-def get_amrita_info(category: Literal["all", "sense", "core", "bot"]) -> str:
+def get_amrita_info(category: str) -> str:
     """Get the AmritaBot's version information
 
     Args:
-        category (str): The category of metadata to get, sense: AmritaSense, core: AmritaCore
+        category (str): The category of metadata to get, available: sense: AmritaSense, core: AmritaCore, bot: AmritaBot itself, all: all metadata
 
     Returns:
         str: metadata of AmritaBot
@@ -152,4 +151,4 @@ def get_amrita_info(category: Literal["all", "sense", "core", "bot"]) -> str:
         "sense": ambot + "\n" + amsense,
         "core": ambot + "\n" + amcore,
         "bot": ambot,
-    }[category]
+    }.get(category, ambot + "\n" + amcore + "\n" + amsense)

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.4.2"
+version = "1.4.2.1"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "GPL-3.0-or-later"


### PR DESCRIPTION
历史遗留问题，core忘记写了

## Summary by Sourcery

Handle unknown metadata categories in the Amrita version info tool and bump the project version.

Bug Fixes:
- Return full metadata when an unknown category is requested in get_amrita_info instead of raising an error.

Enhancements:
- Relax the get_amrita_info category parameter type to a plain string to support more flexible usage.

Build:
- Update project version to 1.4.2.1 in pyproject.toml.