### PR TITLE
Enhance WebUI config editor, prompts, permissions and routing

### DIFF
--- a/.github/workflows/CI.yml
+++ b/.github/workflows/CI.yml
@@ -46,9 +46,9 @@ jobs:
         with:
           args: check . --exit-non-zero-on-fix
 
-      # - name: Frontend typecheck
-      #   run: |
-      #     bash scripts/typecheck.sh
+      - name: Frontend typecheck
+        run: |
+          bash scripts/typecheck.sh
 
       - name: Full build (frontend + package)
         run: |

--- a/.github/workflows/PR.yml
+++ b/.github/workflows/PR.yml
@@ -45,9 +45,9 @@ jobs:
         with:
           args: check . --exit-non-zero-on-fix
 
-      # - name: Frontend typecheck
-      #   run: |
-      #     bash scripts/typecheck.sh
+      - name: Frontend typecheck
+        run: |
+          bash scripts/typecheck.sh
 
       - name: Full build (frontend + package)
         run: |

--- a/MANIFEST.in
+++ b/MANIFEST.in
@@ -1,13 +1,10 @@
 include README.md
 include LICENSE
-recursive-exclude amrita/plugins/webui/service/static/css *
-recursive-include amrita/plugins/webui/service/static/css dist.css
-recursive-include amrita/plugins/webui/service/static/js *
-recursive-include amrita/plugins/webui/service/static/images *
+# WebUI 前端构建产物（index.html / chunk-*.js / chunk-*.css / images）
+# 用目录精确包含，避免 global-include 递归卷进 frontend/node_modules
+recursive-include amrita/plugins/webui/service/static *
 recursive-exclude data *
 recursive-exclude example *
-global-include *.html
-global-include *.js
 global-exclude __pycache__
 global-exclude *.pyc
 global-exclude *.pyo

--- a/amrita/plugins/webui/service/route/menu.py
+++ b/amrita/plugins/webui/service/route/menu.py
@@ -6,6 +6,8 @@
 
 from __future__ import annotations
 
+from amrita.utils.utils import get_amrita_version
+
 from ..main import app
 from ..response import ok
 from ..sidebar import RouteRegistry
@@ -145,4 +147,10 @@ _CORE_ROUTES = [
 async def get_menu():
     """获取全部页面路由注册表（含隐藏页），前端据此生成菜单与路由。"""
     routes = list(_CORE_ROUTES) + RouteRegistry().get_routes()
-    return ok("success", data={"routes": routes})
+    return ok(
+        "success",
+        data={
+            "routes": routes,
+            "version": get_amrita_version(),
+        },
+    )

--- a/frontend/bun.lock
+++ b/frontend/bun.lock
@@ -5,6 +5,9 @@
     "": {
       "name": "amritabot-webui",
       "dependencies": {
+        "@dnd-kit/core": "^6.3.1",
+        "@dnd-kit/sortable": "^10.0.0",
+        "@dnd-kit/utilities": "^3.2.2",
         "@radix-ui/react-dialog": "^1.1.23",
         "@radix-ui/react-label": "^2.1.7",
         "@radix-ui/react-select": "^2.2.6",
@@ -38,6 +41,14 @@
     },
   },
   "packages": {
+    "@dnd-kit/accessibility": ["@dnd-kit/accessibility@3.1.1", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-2P+YgaXF+gRsIihwwY1gCsQSYnu9Zyj2py8kY5fFvUM1qm2WA2u639R6YNVfU4GWr+ZM5mqEsfHZZLoRONbemw=="],
+
+    "@dnd-kit/core": ["@dnd-kit/core@6.3.1", "", { "dependencies": { "@dnd-kit/accessibility": "^3.1.1", "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0", "react-dom": ">=16.8.0" } }, "sha512-xkGBRQQab4RLwgXxoqETICr6S5JlogafbhNsidmrkVv2YRs5MLwpjoF2qpiGjQt8S9AoxtIV603s0GIUpY5eYQ=="],
+
+    "@dnd-kit/sortable": ["@dnd-kit/sortable@10.0.0", "", { "dependencies": { "@dnd-kit/utilities": "^3.2.2", "tslib": "^2.0.0" }, "peerDependencies": { "@dnd-kit/core": "^6.3.0", "react": ">=16.8.0" } }, "sha512-+xqhmIIzvAYMGfBYYnbKuNicfSsk4RksY2XdmJhT+HAC01nix6fHCztU68jooFiMUB01Ky3F0FyOvhG/BZrWkg=="],
+
+    "@dnd-kit/utilities": ["@dnd-kit/utilities@3.2.2", "", { "dependencies": { "tslib": "^2.0.0" }, "peerDependencies": { "react": ">=16.8.0" } }, "sha512-+MKAJEOfaBe5SmV6t34p80MMKhjvUz0vRrvVJbPT0WElzaOJ/1xs+D+KDv+tD/NE5ujfrChEcshd4fLn0wpiqg=="],
+
     "@floating-ui/core": ["@floating-ui/core@1.8.0", "", { "dependencies": { "@floating-ui/utils": "^0.2.12" } }, "sha512-0CIZ5itps/8x7BG8dEIhs53BvCUH2PCoogtakwRTut+Arm58sJooJ0AuZhLw2HJYIR5cMLNPBSS728sPho2khQ=="],
 
     "@floating-ui/dom": ["@floating-ui/dom@1.8.0", "", { "dependencies": { "@floating-ui/core": "^1.8.0", "@floating-ui/utils": "^0.2.12" } }, "sha512-yXSrzeHZBTZadLOlfyhCkJHNeLJnHRnRInwdZ40L7ZiaAtrBwoYlsDrX3v5zB1Utk7CLfzcOVnVVWoXEky7Ceg=="],

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -14,6 +14,9 @@
     "lint:check": "bash ../scripts/lint.sh --check"
   },
   "dependencies": {
+    "@dnd-kit/core": "^6.3.1",
+    "@dnd-kit/sortable": "^10.0.0",
+    "@dnd-kit/utilities": "^3.2.2",
     "@radix-ui/react-dialog": "^1.1.23",
     "@radix-ui/react-label": "^2.1.7",
     "@radix-ui/react-select": "^2.2.6",

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -9,6 +9,7 @@ import { useAuth } from "@/hooks/use-auth";
 import { AppShell } from "@/components/layout/AppShell";
 import { NotFound } from "@/components/shared/PagePlaceholder";
 import { LoginPage } from "@/pages/login";
+import { ForgotPasswordPage } from "@/pages/forgot-password";
 import { PasswordLockedPage } from "@/pages/password-locked";
 import { UiSecLockedPage } from "@/pages/ui-sec-locked";
 
@@ -58,8 +59,16 @@ export function App() {
   // 安全锁：后端检测到默认密码（423），拒绝所有 API 访问，强制更换密码
   if (passwordLocked) return <PasswordLockedPage />;
 
-  // 未登录：首页（/）即登录面板，登录 API 为 POST /api/auth/login
-  if (!user) return <LoginPage />;
+  // 未登录：登录面板 + 忘记密码指导页（登录 API 为 POST /api/auth/login）
+  if (!user) {
+    return (
+      <Routes>
+        <Route path="/forgot-password" element={<ForgotPasswordPage />} />
+        <Route path="/login" element={<LoginPage />} />
+        <Route path="*" element={<LoginPage />} />
+      </Routes>
+    );
+  }
 
   return (
     <Suspense fallback={<Splash />}>

--- a/frontend/src/App.tsx
+++ b/frontend/src/App.tsx
@@ -73,7 +73,15 @@ export function App() {
   return (
     <Suspense fallback={<Splash />}>
       <Routes>
-        <Route path="/" element={<AppShell categories={categories} />}>
+        <Route
+          path="/"
+          element={
+            <AppShell
+              categories={categories}
+              version={menuData?.data.version ?? ""}
+            />
+          }
+        >
           <Route index element={<Navigate to="/dashboard" replace />} />
           {menuRoutes.map(({ path, Component }) => (
             <Route key={path} path={path} element={<Component />} />

--- a/frontend/src/components/layout/AppShell.tsx
+++ b/frontend/src/components/layout/AppShell.tsx
@@ -21,7 +21,14 @@ function useMediaQuery(query: string): boolean {
 }
 
 /** 应用框架：可折叠侧边栏（移动端抽屉）+ 内容区 */
-export function AppShell({ categories }: { categories: MenuCategory[] }) {
+export function AppShell({
+  categories,
+  version,
+}: {
+  categories: MenuCategory[];
+  /** Amrita 版本号（菜单接口附带） */
+  version: string;
+}) {
   const location = useLocation();
   const navigate = useNavigate();
   // 桌面端折叠状态（localStorage 持久化）
@@ -61,6 +68,7 @@ export function AppShell({ categories }: { categories: MenuCategory[] }) {
       )}
       <Sidebar
         categories={categories}
+        version={version}
         activePath={location.pathname}
         collapsed={collapsed}
         mobileOpen={isMobile && mobileOpen}

--- a/frontend/src/components/layout/Sidebar.tsx
+++ b/frontend/src/components/layout/Sidebar.tsx
@@ -50,6 +50,7 @@ function resolveIcon(name: string | null | undefined): LucideIcon {
 
 export function Sidebar({
   categories,
+  version,
   activePath,
   collapsed,
   mobileOpen,
@@ -58,6 +59,8 @@ export function Sidebar({
   onNavigate,
 }: {
   categories: MenuCategory[];
+  /** Amrita 版本号（v0.1.0 格式展示） */
+  version: string;
   activePath: string;
   collapsed: boolean;
   /** 移动端抽屉是否打开（仅 <lg 生效） */
@@ -89,9 +92,16 @@ export function Sidebar({
               alt="AmritaBot"
               className="h-7 w-7 shrink-0 rounded-full"
             />
-            <span className="truncate text-lg font-semibold tracking-tight">
-              AmritaBot
-            </span>
+            <div className="flex min-w-0 flex-col leading-tight">
+              <span className="truncate text-lg font-semibold tracking-tight">
+                AmritaBot
+              </span>
+              {version && (
+                <span className="truncate text-[10px] text-sidebar-foreground/60">
+                  v{version}
+                </span>
+              )}
+            </div>
           </div>
         )}
         <div className="flex items-center gap-1">

--- a/frontend/src/components/shared/PermissionEditor.tsx
+++ b/frontend/src/components/shared/PermissionEditor.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { Plus, X } from "lucide-react";
+import { AlertTriangle, Plus, X } from "lucide-react";
 import { Button } from "@/components/ui/button";
 import { Input } from "@/components/ui/input";
 import { Switch } from "@/components/ui/switch";
@@ -10,46 +10,73 @@ import { cn } from "@/lib/utils";
  *
  * - 每行 = 权限节点（Input）+ 允许/拒绝（Switch）+ 删除
  * - 空占位行：允许存在但保持唯一（已有空行时不重复添加），保存时自动过滤
+ * - 无法解析的行（注释、单节点等）：保留为只读原始行，保存时原样写回，不静默丢弃
  * - 行 key 使用唯一 id（非 index），保证占位行增删时状态不串位
  */
 
 interface PermRow {
-  /** 行唯一 id（crypto.randomUUID），仅作 React key，不参与序列化 */
+  /** 行唯一 id，仅作 React key，不参与序列化 */
   id: string;
   /** 权限节点路径，如 chat.send */
   node: string;
   /** true=允许，false=拒绝 */
   has: boolean;
+  /** 无法解析的原始行（如注释 `# ...`、单节点行），序列化时原样写回 */
+  raw?: string;
+}
+
+/** 行 id：优先 crypto.randomUUID，不可用（旧浏览器/非安全上下文）时降级时间戳+随机数 */
+function createPermRowId(): string {
+  const cryptoObj =
+    typeof globalThis !== "undefined"
+      ? (
+          globalThis as {
+            crypto?: { randomUUID?: () => string };
+          }
+        ).crypto
+      : undefined;
+  if (cryptoObj && typeof cryptoObj.randomUUID === "function") {
+    return cryptoObj.randomUUID();
+  }
+  return `${Date.now()}-${Math.random().toString(16).slice(2)}`;
 }
 
 function newRow(): PermRow {
-  return { id: crypto.randomUUID(), node: "", has: false };
+  return { id: createPermRowId(), node: "", has: false };
 }
 
-/** 解析权限字符串（每行 `node true/false`）为行数组 */
+/** 解析权限字符串（每行 `node true/false`）为行数组；无法解析的行保留原文 */
 function parsePermStr(permStr: string): PermRow[] {
   const rows: PermRow[] = [];
   for (const line of permStr.split("\n")) {
     const trimmed = line.trim();
     if (!trimmed) continue;
     const parts = trimmed.split(/\s+/);
-    if (parts.length < 2) continue;
     const [node, state] = parts;
-    if (!node || !state) continue;
-    rows.push({
-      id: crypto.randomUUID(),
-      node,
-      has: state.toLowerCase() === "true",
-    });
+    if (parts.length >= 2 && node && state) {
+      rows.push({
+        id: createPermRowId(),
+        node,
+        has: state.toLowerCase() === "true",
+      });
+    } else {
+      // 注释 / 单节点等无法解析的行：保留原文，避免保存时静默丢失
+      rows.push({
+        id: createPermRowId(),
+        node: "",
+        has: false,
+        raw: trimmed,
+      });
+    }
   }
   return rows;
 }
 
-/** 序列化行数组为权限字符串（过滤空节点行） */
+/** 序列化行数组为权限字符串（空节点行过滤，原始行原样输出） */
 function serializeRows(rows: PermRow[]): string {
   return rows
-    .filter((r) => r.node.trim() !== "")
-    .map((r) => `${r.node.trim()} ${r.has ? "true" : "false"}`)
+    .filter((r) => r.node.trim() !== "" || r.raw !== undefined)
+    .map((r) => r.raw ?? `${r.node.trim()} ${r.has ? "true" : "false"}`)
     .join("\n");
 }
 
@@ -95,42 +122,71 @@ export function PermissionEditor({
           （暂无权限，点击下方「添加权限」开始）
         </p>
       )}
-      {rows.map((row) => (
-        <div key={row.id} className="flex items-center gap-2">
-          <Input
-            value={row.node}
-            onChange={(e) => updateNode(row.id, e.target.value)}
-            className="font-mono text-xs"
-            placeholder="权限节点，如 chat.send"
-            spellCheck={false}
-          />
-          <span
-            className={cn(
-              "flex h-8 w-16 shrink-0 items-center justify-center gap-1.5 rounded-md border px-2 text-xs font-medium",
-              row.has
-                ? "border-primary/30 bg-primary/10 text-primary"
-                : "border-destructive/30 bg-destructive/10 text-destructive",
-            )}
+      {rows.map((row) =>
+        row.raw !== undefined ? (
+          /* 无法解析的原始行：只读展示（可删除），保存时原样保留 */
+          <div
+            key={row.id}
+            className="flex items-center gap-2 rounded-md border border-dashed border-border bg-muted/40 px-3 py-2"
           >
-            {row.has ? "允许" : "拒绝"}
-          </span>
-          <Switch
-            checked={row.has}
-            onCheckedChange={(checked) => updateHas(row.id, checked)}
-            aria-label={`${row.node || "空节点"} 权限开关`}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-            onClick={() => removeRow(row.id)}
-            aria-label="删除该权限"
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      ))}
+            <AlertTriangle className="h-4 w-4 shrink-0 text-muted-foreground" />
+            <code
+              className="flex-1 truncate font-mono text-xs text-muted-foreground"
+              title={row.raw}
+            >
+              {row.raw}
+            </code>
+            <span className="shrink-0 text-[10px] text-muted-foreground">
+              原样保留
+            </span>
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-7 w-7 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeRow(row.id)}
+              aria-label="删除该行"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ) : (
+          <div key={row.id} className="flex items-center gap-2">
+            <Input
+              value={row.node}
+              onChange={(e) => updateNode(row.id, e.target.value)}
+              className="font-mono text-xs"
+              placeholder="权限节点，如 chat.send"
+              spellCheck={false}
+            />
+            <span
+              className={cn(
+                "flex h-8 w-16 shrink-0 items-center justify-center gap-1.5 rounded-md border px-2 text-xs font-medium",
+                row.has
+                  ? "border-primary/30 bg-primary/10 text-primary"
+                  : "border-destructive/30 bg-destructive/10 text-destructive",
+              )}
+            >
+              {row.has ? "允许" : "拒绝"}
+            </span>
+            <Switch
+              checked={row.has}
+              onCheckedChange={(checked) => updateHas(row.id, checked)}
+              aria-label={`${row.node || "空节点"} 权限开关`}
+            />
+            <Button
+              type="button"
+              variant="ghost"
+              size="icon"
+              className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+              onClick={() => removeRow(row.id)}
+              aria-label="删除该权限"
+            >
+              <X className="h-4 w-4" />
+            </Button>
+          </div>
+        ),
+      )}
       <div className="flex items-center justify-between">
         <Button type="button" variant="outline" size="sm" onClick={addRow}>
           <Plus className="mr-1 h-4 w-4" /> 添加权限

--- a/frontend/src/components/shared/PermissionEditor.tsx
+++ b/frontend/src/components/shared/PermissionEditor.tsx
@@ -1,0 +1,147 @@
+import { useState } from "react";
+import { Plus, X } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Input } from "@/components/ui/input";
+import { Switch } from "@/components/ui/switch";
+import { cn } from "@/lib/utils";
+
+/**
+ * 权限编辑器：结构化行编辑（替代直接编辑权限字符串）
+ *
+ * - 每行 = 权限节点（Input）+ 允许/拒绝（Switch）+ 删除
+ * - 空占位行：允许存在但保持唯一（已有空行时不重复添加），保存时自动过滤
+ * - 行 key 使用唯一 id（非 index），保证占位行增删时状态不串位
+ */
+
+interface PermRow {
+  /** 行唯一 id（crypto.randomUUID），仅作 React key，不参与序列化 */
+  id: string;
+  /** 权限节点路径，如 chat.send */
+  node: string;
+  /** true=允许，false=拒绝 */
+  has: boolean;
+}
+
+function newRow(): PermRow {
+  return { id: crypto.randomUUID(), node: "", has: false };
+}
+
+/** 解析权限字符串（每行 `node true/false`）为行数组 */
+function parsePermStr(permStr: string): PermRow[] {
+  const rows: PermRow[] = [];
+  for (const line of permStr.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+    const parts = trimmed.split(/\s+/);
+    if (parts.length < 2) continue;
+    const [node, state] = parts;
+    if (!node || !state) continue;
+    rows.push({
+      id: crypto.randomUUID(),
+      node,
+      has: state.toLowerCase() === "true",
+    });
+  }
+  return rows;
+}
+
+/** 序列化行数组为权限字符串（过滤空节点行） */
+function serializeRows(rows: PermRow[]): string {
+  return rows
+    .filter((r) => r.node.trim() !== "")
+    .map((r) => `${r.node.trim()} ${r.has ? "true" : "false"}`)
+    .join("\n");
+}
+
+export function PermissionEditor({
+  initial,
+  onSubmit,
+  submitting,
+}: {
+  /** 初始权限字符串（每行 `node true/false`） */
+  initial: string;
+  onSubmit: (permStr: string) => void;
+  submitting: boolean;
+}) {
+  const [rows, setRows] = useState<PermRow[]>(() => parsePermStr(initial));
+  const [dirty, setDirty] = useState(false);
+
+  function updateNode(id: string, node: string) {
+    setDirty(true);
+    setRows((rs) => rs.map((r) => (r.id === id ? { ...r, node } : r)));
+  }
+
+  function updateHas(id: string, has: boolean) {
+    setDirty(true);
+    setRows((rs) => rs.map((r) => (r.id === id ? { ...r, has } : r)));
+  }
+
+  function removeRow(id: string) {
+    setDirty(true);
+    setRows((rs) => rs.filter((r) => r.id !== id));
+  }
+
+  function addRow() {
+    // 空占位行保持唯一：已有空节点行时不重复添加
+    if (rows.some((r) => r.node.trim() === "")) return;
+    setDirty(true);
+    setRows((rs) => [...rs, newRow()]);
+  }
+
+  return (
+    <div className="space-y-3">
+      {rows.length === 0 && (
+        <p className="flex min-h-9 items-center rounded-md border border-dashed px-3 text-xs text-muted-foreground">
+          （暂无权限，点击下方「添加权限」开始）
+        </p>
+      )}
+      {rows.map((row) => (
+        <div key={row.id} className="flex items-center gap-2">
+          <Input
+            value={row.node}
+            onChange={(e) => updateNode(row.id, e.target.value)}
+            className="font-mono text-xs"
+            placeholder="权限节点，如 chat.send"
+            spellCheck={false}
+          />
+          <span
+            className={cn(
+              "flex h-8 w-16 shrink-0 items-center justify-center gap-1.5 rounded-md border px-2 text-xs font-medium",
+              row.has
+                ? "border-primary/30 bg-primary/10 text-primary"
+                : "border-destructive/30 bg-destructive/10 text-destructive",
+            )}
+          >
+            {row.has ? "允许" : "拒绝"}
+          </span>
+          <Switch
+            checked={row.has}
+            onCheckedChange={(checked) => updateHas(row.id, checked)}
+            aria-label={`${row.node || "空节点"} 权限开关`}
+          />
+          <Button
+            type="button"
+            variant="ghost"
+            size="icon"
+            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+            onClick={() => removeRow(row.id)}
+            aria-label="删除该权限"
+          >
+            <X className="h-4 w-4" />
+          </Button>
+        </div>
+      ))}
+      <div className="flex items-center justify-between">
+        <Button type="button" variant="outline" size="sm" onClick={addRow}>
+          <Plus className="mr-1 h-4 w-4" /> 添加权限
+        </Button>
+        <Button
+          onClick={() => onSubmit(serializeRows(rows))}
+          disabled={submitting || !dirty}
+        >
+          {submitting ? "保存中…" : "保存"}
+        </Button>
+      </div>
+    </div>
+  );
+}

--- a/frontend/src/components/ui/tabs.tsx
+++ b/frontend/src/components/ui/tabs.tsx
@@ -1,0 +1,116 @@
+import { createContext, useContext, useState, type ReactNode } from "react";
+import { cn } from "@/lib/utils";
+
+/**
+ * 自写 Tabs：按钮自身对比度高亮 + 内容淡入动效
+ *
+ * - 高亮：active 按钮自身切换为背景色 + 阴影 + 描边（对比度区分，不遮挡文字）
+ * - 动效：按钮背景/文字颜色过渡，切换时内容区淡入上移（tw-animate-css）
+ */
+
+interface TabsContextValue {
+  value: string;
+  setValue: (v: string) => void;
+}
+
+const TabsContext = createContext<TabsContextValue | null>(null);
+
+function useTabsContext() {
+  const ctx = useContext(TabsContext);
+  if (!ctx) throw new Error("Tabs 组件必须在 Tabs 内使用");
+  return ctx;
+}
+
+export function Tabs({
+  defaultValue,
+  className,
+  children,
+}: {
+  defaultValue: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const [value, setValue] = useState(defaultValue);
+  return (
+    <TabsContext.Provider value={{ value, setValue }}>
+      <div className={cn("flex flex-col gap-3", className)}>{children}</div>
+    </TabsContext.Provider>
+  );
+}
+
+export function TabsList({
+  className,
+  children,
+}: {
+  className?: string;
+  children: ReactNode;
+}) {
+  return (
+    <div
+      role="tablist"
+      className={cn(
+        "inline-flex h-9 w-fit items-center gap-1 rounded-lg bg-muted p-1",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}
+
+export function TabsTrigger({
+  value,
+  className,
+  children,
+}: {
+  value: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const { value: active, setValue } = useTabsContext();
+  const isActive = active === value;
+  return (
+    <button
+      type="button"
+      role="tab"
+      aria-selected={isActive}
+      data-tab={value}
+      onClick={() => setValue(value)}
+      className={cn(
+        "inline-flex h-7 items-center justify-center whitespace-nowrap rounded-md px-3 text-sm font-medium transition-all duration-200",
+        // active：背景色 + 阴影 + 描边形成高对比度高亮；inactive：弱化文字
+        isActive
+          ? "bg-background text-foreground shadow-sm ring-1 ring-border"
+          : "text-muted-foreground hover:text-foreground",
+        className,
+      )}
+    >
+      {children}
+    </button>
+  );
+}
+
+export function TabsContent({
+  value,
+  className,
+  children,
+}: {
+  value: string;
+  className?: string;
+  children: ReactNode;
+}) {
+  const { value: active } = useTabsContext();
+  if (active !== value) return null;
+  return (
+    <div
+      role="tabpanel"
+      data-tab-panel={value}
+      className={cn(
+        "animate-in fade-in slide-in-from-top-1 duration-200",
+        className,
+      )}
+    >
+      {children}
+    </div>
+  );
+}

--- a/frontend/src/frontend.tsx
+++ b/frontend/src/frontend.tsx
@@ -5,7 +5,7 @@
 
 import { StrictMode } from "react";
 import { createRoot } from "react-dom/client";
-import { BrowserRouter } from "react-router-dom";
+import { createBrowserRouter, RouterProvider } from "react-router-dom";
 import { QueryClient, QueryClientProvider } from "@tanstack/react-query";
 import { Toaster } from "@/components/ui/sonner";
 import { AuthProvider } from "@/hooks/use-auth";
@@ -17,16 +17,25 @@ const queryClient = new QueryClient({
   },
 });
 
+// data router：启用 useBlocker（未保存修改拦截导航）等 data router 能力
+// AuthProvider 需包裹 App（useAuth 依赖其上下文）
+const router = createBrowserRouter([
+  {
+    path: "*",
+    element: (
+      <AuthProvider>
+        <App />
+      </AuthProvider>
+    ),
+  },
+]);
+
 const elem = document.getElementById("root")!;
 const app = (
   <StrictMode>
     <QueryClientProvider client={queryClient}>
-      <BrowserRouter>
-        <AuthProvider>
-          <App />
-          <Toaster />
-        </AuthProvider>
-      </BrowserRouter>
+      <RouterProvider router={router} />
+      <Toaster />
     </QueryClientProvider>
   </StrictMode>
 );

--- a/frontend/src/index.ts
+++ b/frontend/src/index.ts
@@ -172,6 +172,10 @@ const server = serve<WsUpgradeData>({
     if (url.pathname.startsWith("/api/")) {
       return await proxyApi(req);
     }
+    // 静态资源代理（/static/*）：logo、favicon 等由后端托管
+    if (url.pathname.startsWith("/static/")) {
+      return await proxyApi(req);
+    }
     // 静态资源（/src/*，CSS 走 tailwind 编译管道）
     const staticRes = await serveStatic(url.pathname);
     if (staticRes) return staticRes;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -11,6 +11,8 @@ export interface MenuRoute {
 
 export interface MenuData {
   routes: MenuRoute[];
+  /** Amrita 版本号（如 0.1.0），用于侧边栏等展示 */
+  version: string;
 }
 
 /** 认证 */

--- a/frontend/src/pages/forgot-password.tsx
+++ b/frontend/src/pages/forgot-password.tsx
@@ -1,0 +1,84 @@
+import { useNavigate } from "react-router-dom";
+import { ArrowLeft, KeyRound } from "lucide-react";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader } from "@/components/ui/card";
+
+/**
+ * 忘记密码页：WebUI 密码由环境变量配置，前端无法自助重置，
+ * 本页指导用户通过 .env 环境变量重置密码。
+ */
+export function ForgotPasswordPage() {
+  const navigate = useNavigate();
+
+  return (
+    <div className="grid min-h-screen place-items-center bg-background p-4">
+      <Card className="w-full max-w-md">
+        <CardHeader className="text-center">
+          <div className="mx-auto flex h-14 w-14 items-center justify-center rounded-full bg-primary/10">
+            <KeyRound className="h-7 w-7 text-primary" />
+          </div>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="text-center">
+            <h1 className="text-xl font-semibold tracking-tight">忘记密码</h1>
+            <p className="mt-1 text-sm text-muted-foreground">
+              WebUI 登录密码由服务器环境变量配置，无法在页面内自助重置。
+              请在服务器上按以下步骤修改：
+            </p>
+          </div>
+
+          <div className="space-y-3 rounded-md bg-muted p-4 text-sm">
+            <ol className="list-decimal space-y-2 pl-5 text-muted-foreground">
+              <li>
+                编辑 Bot 根目录的{" "}
+                <code className="rounded bg-background px-1 font-mono text-xs text-primary">
+                  .env
+                </code>{" "}
+                文件（或设置同名环境变量）
+              </li>
+              <li>
+                修改/添加{" "}
+                <code className="rounded bg-background px-1 font-mono text-xs text-primary">
+                  WEBUI_PASSWORD=你的新密码
+                </code>
+              </li>
+              <li>
+                （可选）修改用户名{" "}
+                <code className="rounded bg-background px-1 font-mono text-xs text-primary">
+                  WEBUI_USER_NAME=你的用户名
+                </code>
+              </li>
+              <li>重启 Amrita（重启后自动生效），返回本页重新登录</li>
+            </ol>
+            <div className="rounded border border-border bg-background p-3 font-mono text-xs leading-relaxed text-muted-foreground">
+              <p>
+                <span className="text-muted-foreground/70"># .env 示例</span>
+              </p>
+              <p>
+                <span className="text-primary">WEBUI_USER_NAME</span>=admin
+              </p>
+              <p>
+                <span className="text-primary">WEBUI_PASSWORD</span>
+                =your-strong-password
+              </p>
+            </div>
+          </div>
+
+          <p className="text-xs leading-relaxed text-muted-foreground">
+            提示：若因登录失败次数过多导致 WebUI 锁定，重启 Amrita 即可解除
+            （锁定状态仅存在于内存）。
+          </p>
+
+          <Button
+            variant="outline"
+            className="w-full"
+            onClick={() => navigate("/login", { replace: true })}
+          >
+            <ArrowLeft className="h-4 w-4" />
+            返回登录
+          </Button>
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/login.tsx
+++ b/frontend/src/pages/login.tsx
@@ -1,5 +1,5 @@
 import { useState } from "react";
-import { useNavigate } from "react-router-dom";
+import { Link, useNavigate } from "react-router-dom";
 import { Github, HelpCircle } from "lucide-react";
 import { useAuth } from "@/hooks/use-auth";
 import { ApiError } from "@/lib/api";
@@ -79,19 +79,13 @@ export function LoginPage() {
             </Button>
           </form>
           <div className="flex items-center justify-between pt-1 text-xs text-muted-foreground">
-            <button
-              type="button"
+            <Link
+              to="/forgot-password"
               className="inline-flex items-center gap-1 hover:text-foreground"
-              onClick={() =>
-                window.open(
-                  "https://github.com/AmritaBot/AmritaBot#Amrita 自定义配置",
-                  "_blank",
-                )
-              }
             >
               <HelpCircle className="h-3.5 w-3.5" />
               忘记密码？
-            </button>
+            </Link>
             <a
               href="https://github.com/AmritaBot/AmritaBot"
               target="_blank"

--- a/frontend/src/pages/manage/prompts.tsx
+++ b/frontend/src/pages/manage/prompts.tsx
@@ -37,6 +37,7 @@ export function PromptsPage() {
     queryFn: () => api.get<ChatPromptsData>("/api/chat/prompts"),
   });
 
+  // 创建用 mutateAsync：PromptTab 需在成功后才关闭对话框（失败保留输入）
   const createMutation = useMutation({
     mutationFn: ({
       type,
@@ -139,7 +140,9 @@ export function PromptsPage() {
           prompts={data?.data.prompts.group ?? []}
           loading={isLoading}
           onCreate={(name, text) =>
-            createMutation.mutate({ type: "group", name, text })
+            createMutation
+              .mutateAsync({ type: "group", name, text })
+              .then(() => {})
           }
           onEdit={setEditing}
           onDelete={setDeleting}
@@ -151,7 +154,9 @@ export function PromptsPage() {
           prompts={data?.data.prompts.private ?? []}
           loading={isLoading}
           onCreate={(name, text) =>
-            createMutation.mutate({ type: "private", name, text })
+            createMutation
+              .mutateAsync({ type: "private", name, text })
+              .then(() => {})
           }
           onEdit={setEditing}
           onDelete={setDeleting}
@@ -177,7 +182,7 @@ function PromptTab({
   title: string;
   prompts: ChatPrompt[];
   loading: boolean;
-  onCreate: (name: string, text: string) => void;
+  onCreate: (name: string, text: string) => Promise<void>;
   onEdit: (row: PromptRow) => void;
   onDelete: (row: PromptRow) => void;
   deletePending: boolean;
@@ -185,6 +190,22 @@ function PromptTab({
   const [createOpen, setCreateOpen] = useState(false);
   const [newName, setNewName] = useState("");
   const [newText, setNewText] = useState("");
+  const [creating, setCreating] = useState(false);
+
+  /** 创建成功才关闭并清空；失败保留输入（错误 toast 由 mutation onError 处理） */
+  async function handleCreate() {
+    setCreating(true);
+    try {
+      await onCreate(newName, newText);
+      setCreateOpen(false);
+      setNewName("");
+      setNewText("");
+    } catch {
+      // 创建失败：保留表单内容，用户可修正后重试
+    } finally {
+      setCreating(false);
+    }
+  }
 
   const rows: PromptRow[] = prompts.map((p) => ({ ...p, type: value }));
 
@@ -261,16 +282,8 @@ function PromptTab({
                 </div>
               </div>
               <DialogFooter>
-                <Button
-                  onClick={() => {
-                    onCreate(newName, newText);
-                    setCreateOpen(false);
-                    setNewName("");
-                    setNewText("");
-                  }}
-                  disabled={!newName}
-                >
-                  创建
+                <Button onClick={handleCreate} disabled={!newName || creating}>
+                  {creating ? "创建中…" : "创建"}
                 </Button>
               </DialogFooter>
             </DialogContent>

--- a/frontend/src/pages/manage/prompts.tsx
+++ b/frontend/src/pages/manage/prompts.tsx
@@ -18,6 +18,7 @@ import {
   DialogTrigger,
 } from "@/components/ui/dialog";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Tabs, TabsContent, TabsList, TabsTrigger } from "@/components/ui/tabs";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 type PromptType = "group" | "private";
@@ -28,40 +29,26 @@ interface PromptRow extends ChatPrompt {
 
 export function PromptsPage() {
   const qc = useQueryClient();
-  const [createOpen, setCreateOpen] = useState(false);
-  const [createType, setCreateType] = useState<PromptType>("group");
   const [editing, setEditing] = useState<PromptRow | null>(null);
   const [deleting, setDeleting] = useState<PromptRow | null>(null);
-  const [newName, setNewName] = useState("");
-  const [newText, setNewText] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: ["chat-prompts"],
     queryFn: () => api.get<ChatPromptsData>("/api/chat/prompts"),
   });
 
-  const rows: PromptRow[] = [
-    ...(data?.data.prompts.group.map((p) => ({
-      ...p,
-      type: "group" as const,
-    })) ?? []),
-    ...(data?.data.prompts.private.map((p) => ({
-      ...p,
-      type: "private" as const,
-    })) ?? []),
-  ];
-
   const createMutation = useMutation({
-    mutationFn: () =>
-      api.post(`/api/chat/prompts/${createType}`, {
-        name: newName,
-        text: newText,
-      }),
+    mutationFn: ({
+      type,
+      name,
+      text,
+    }: {
+      type: PromptType;
+      name: string;
+      text: string;
+    }) => api.post(`/api/chat/prompts/${type}`, { name, text }),
     onSuccess: (res) => {
       toast.success(res.message);
-      setCreateOpen(false);
-      setNewName("");
-      setNewText("");
       void qc.invalidateQueries({ queryKey: ["chat-prompts"] });
     },
     onError: (e: Error) => toast.error(e.message),
@@ -88,53 +75,12 @@ export function PromptsPage() {
       ),
     onSuccess: (res) => {
       toast.success(res.message);
+      // 关闭确认框：删除成功后立即收起（否则对话框残留已删除的条目）
+      setDeleting(null);
       void qc.invalidateQueries({ queryKey: ["chat-prompts"] });
     },
     onError: (e: Error) => toast.error(e.message),
   });
-
-  const columns: Column<PromptRow>[] = [
-    {
-      key: "type",
-      header: "类型",
-      render: (p) => (p.type === "group" ? "群聊" : "私聊"),
-    },
-    {
-      key: "name",
-      header: "名称",
-      render: (p) => <span className="font-medium">{p.name}</span>,
-    },
-    {
-      key: "text",
-      header: "内容",
-      render: (p) => (
-        <span className="line-clamp-1 max-w-lg text-muted-foreground">
-          {p.text}
-        </span>
-      ),
-    },
-    {
-      key: "actions",
-      header: "操作",
-      render: (p) => (
-        <div className="flex gap-2">
-          <Button variant="outline" size="sm" onClick={() => setEditing(p)}>
-            编辑
-          </Button>
-          {p.name !== "default" && (
-            <Button
-              variant="destructive"
-              size="sm"
-              onClick={() => setDeleting(p)}
-              disabled={deleteMutation.isPending}
-            >
-              删除
-            </Button>
-          )}
-        </div>
-      ),
-    },
-  ];
 
   return (
     <div className="space-y-6">
@@ -150,71 +96,9 @@ export function PromptsPage() {
         }}
       />
 
-      <div className="flex items-center justify-between">
-        <div>
-          <h1 className="text-2xl font-semibold tracking-tight">提示词预设</h1>
-          <p className="text-sm text-muted-foreground">群聊 / 私聊提示词管理</p>
-        </div>
-        <Dialog open={createOpen} onOpenChange={setCreateOpen}>
-          <DialogTrigger asChild>
-            <Button>
-              <Plus className="mr-1 h-4 w-4" />
-              新建提示词
-            </Button>
-          </DialogTrigger>
-          <DialogContent>
-            <DialogHeader>
-              <DialogTitle>新建提示词</DialogTitle>
-            </DialogHeader>
-            <div className="space-y-4">
-              <div className="space-y-2">
-                <Label>类型</Label>
-                <div className="flex gap-2">
-                  <Button
-                    type="button"
-                    variant={createType === "group" ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setCreateType("group")}
-                  >
-                    群聊
-                  </Button>
-                  <Button
-                    type="button"
-                    variant={createType === "private" ? "default" : "outline"}
-                    size="sm"
-                    onClick={() => setCreateType("private")}
-                  >
-                    私聊
-                  </Button>
-                </div>
-              </div>
-              <div className="space-y-2">
-                <Label>名称</Label>
-                <Input
-                  value={newName}
-                  onChange={(e) => setNewName(e.target.value)}
-                  placeholder="如：default"
-                />
-              </div>
-              <div className="space-y-2">
-                <Label>内容</Label>
-                <Textarea
-                  value={newText}
-                  onChange={(e) => setNewText(e.target.value)}
-                  className="h-40 resize-y"
-                />
-              </div>
-            </div>
-            <DialogFooter>
-              <Button
-                onClick={() => createMutation.mutate()}
-                disabled={!newName || createMutation.isPending}
-              >
-                {createMutation.isPending ? "创建中…" : "创建"}
-              </Button>
-            </DialogFooter>
-          </DialogContent>
-        </Dialog>
+      <div>
+        <h1 className="text-2xl font-semibold tracking-tight">提示词预设</h1>
+        <p className="text-sm text-muted-foreground">群聊 / 私聊提示词管理</p>
       </div>
 
       <Dialog
@@ -244,20 +128,164 @@ export function PromptsPage() {
         </DialogContent>
       </Dialog>
 
+      <Tabs defaultValue="group">
+        <TabsList>
+          <TabsTrigger value="group">群聊提示词</TabsTrigger>
+          <TabsTrigger value="private">私聊提示词</TabsTrigger>
+        </TabsList>
+        <PromptTab
+          value="group"
+          title="群聊提示词"
+          prompts={data?.data.prompts.group ?? []}
+          loading={isLoading}
+          onCreate={(name, text) =>
+            createMutation.mutate({ type: "group", name, text })
+          }
+          onEdit={setEditing}
+          onDelete={setDeleting}
+          deletePending={deleteMutation.isPending}
+        />
+        <PromptTab
+          value="private"
+          title="私聊提示词"
+          prompts={data?.data.prompts.private ?? []}
+          loading={isLoading}
+          onCreate={(name, text) =>
+            createMutation.mutate({ type: "private", name, text })
+          }
+          onEdit={setEditing}
+          onDelete={setDeleting}
+          deletePending={deleteMutation.isPending}
+        />
+      </Tabs>
+    </div>
+  );
+}
+
+/** 单个 tab 版块：提示词列表 + 该类型的新建入口 */
+function PromptTab({
+  value,
+  title,
+  prompts,
+  loading,
+  onCreate,
+  onEdit,
+  onDelete,
+  deletePending,
+}: {
+  value: PromptType;
+  title: string;
+  prompts: ChatPrompt[];
+  loading: boolean;
+  onCreate: (name: string, text: string) => void;
+  onEdit: (row: PromptRow) => void;
+  onDelete: (row: PromptRow) => void;
+  deletePending: boolean;
+}) {
+  const [createOpen, setCreateOpen] = useState(false);
+  const [newName, setNewName] = useState("");
+  const [newText, setNewText] = useState("");
+
+  const rows: PromptRow[] = prompts.map((p) => ({ ...p, type: value }));
+
+  const columns: Column<PromptRow>[] = [
+    {
+      key: "name",
+      header: "名称",
+      render: (p) => <span className="font-medium">{p.name}</span>,
+    },
+    {
+      key: "text",
+      header: "内容",
+      render: (p) => (
+        <span className="line-clamp-1 max-w-lg text-muted-foreground">
+          {p.text}
+        </span>
+      ),
+    },
+    {
+      key: "actions",
+      header: "操作",
+      render: (p) => (
+        <div className="flex gap-2">
+          <Button variant="outline" size="sm" onClick={() => onEdit(p)}>
+            编辑
+          </Button>
+          {p.name !== "default" && (
+            <Button
+              variant="destructive"
+              size="sm"
+              onClick={() => onDelete(p)}
+              disabled={deletePending}
+            >
+              删除
+            </Button>
+          )}
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <TabsContent value={value}>
       <Card>
-        <CardHeader>
-          <CardTitle className="text-base">提示词列表</CardTitle>
+        <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
+          <CardTitle className="text-base">{title}</CardTitle>
+          <Dialog open={createOpen} onOpenChange={setCreateOpen}>
+            <DialogTrigger asChild>
+              <Button size="sm">
+                <Plus className="mr-1 h-4 w-4" />
+                新建
+              </Button>
+            </DialogTrigger>
+            <DialogContent>
+              <DialogHeader>
+                <DialogTitle>新建{title}</DialogTitle>
+              </DialogHeader>
+              <div className="space-y-4">
+                <div className="space-y-2">
+                  <Label>名称</Label>
+                  <Input
+                    value={newName}
+                    onChange={(e) => setNewName(e.target.value)}
+                    placeholder="如：default"
+                  />
+                </div>
+                <div className="space-y-2">
+                  <Label>内容</Label>
+                  <Textarea
+                    value={newText}
+                    onChange={(e) => setNewText(e.target.value)}
+                    className="h-40 resize-y"
+                  />
+                </div>
+              </div>
+              <DialogFooter>
+                <Button
+                  onClick={() => {
+                    onCreate(newName, newText);
+                    setCreateOpen(false);
+                    setNewName("");
+                    setNewText("");
+                  }}
+                  disabled={!newName}
+                >
+                  创建
+                </Button>
+              </DialogFooter>
+            </DialogContent>
+          </Dialog>
         </CardHeader>
         <CardContent>
           <DataTable
             columns={columns}
             data={rows}
-            loading={isLoading}
-            emptyText="还没有提示词"
+            loading={loading}
+            emptyText={`还没有${title}`}
           />
         </CardContent>
       </Card>
-    </div>
+    </TabsContent>
   );
 }
 

--- a/frontend/src/pages/system/confedit-editor.tsx
+++ b/frontend/src/pages/system/confedit-editor.tsx
@@ -1,8 +1,30 @@
-import { useMemo, useState } from "react";
+import { useEffect, useMemo, useState } from "react";
+import {
+  DndContext,
+  PointerSensor,
+  closestCenter,
+  useSensor,
+  useSensors,
+  type DragEndEvent,
+} from "@dnd-kit/core";
+import {
+  SortableContext,
+  arrayMove,
+  useSortable,
+  verticalListSortingStrategy,
+} from "@dnd-kit/sortable";
+import { CSS } from "@dnd-kit/utilities";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
-import { useParams } from "react-router-dom";
+import { useBlocker, useParams } from "react-router-dom";
 import { toast } from "sonner";
-import { Plus, X } from "lucide-react";
+import {
+  ChevronDown,
+  ChevronRight,
+  GripVertical,
+  Plus,
+  SearchX,
+  X,
+} from "lucide-react";
 import { api, ApiError } from "@/lib/api";
 import type { ConfeditField, ConfeditSchemaData } from "@/lib/types";
 import { Button } from "@/components/ui/button";
@@ -28,6 +50,155 @@ import {
 /** schema 驱动的动态配置编辑器 */
 
 type FieldValue = string | number | boolean | string[] | null;
+
+/** 嵌套树节点：叶子为配置字段，非叶子为分组（按 "." 分层） */
+interface FieldTreeNode {
+  /** 完整路径，如 a.b.c */
+  key: string;
+  /** 本层名称，如 c */
+  label: string;
+  /** 叶子字段；分组节点为 null */
+  field: ConfeditField | null;
+  children: FieldTreeNode[];
+}
+
+/** 展平字段（a.b.c）重组为嵌套树 */
+function buildFieldTree(fields: ConfeditField[]): FieldTreeNode[] {
+  const root: FieldTreeNode[] = [];
+  for (const field of fields) {
+    const parts = field.name.split(".");
+    let level = root;
+    let path = "";
+    for (const part of parts) {
+      path = path ? `${path}.${part}` : part;
+      let node = level.find((n) => n.key === path);
+      if (!node) {
+        node = { key: path, label: part, field: null, children: [] };
+        level.push(node);
+      }
+      if (part === parts[parts.length - 1]) {
+        node.field = field;
+      } else {
+        level = node.children;
+      }
+    }
+  }
+  return root;
+}
+
+/** 按关键词过滤树：命中叶子保留，组仅保留含命中叶子的分支 */
+function filterFieldTree(
+  nodes: FieldTreeNode[],
+  keyword: string,
+): FieldTreeNode[] {
+  const lower = keyword.trim().toLowerCase();
+  if (!lower) return nodes;
+  const result: FieldTreeNode[] = [];
+  for (const node of nodes) {
+    if (node.field) {
+      const hit =
+        node.field.name.toLowerCase().includes(lower) ||
+        (node.field.description ?? "").toLowerCase().includes(lower);
+      if (hit) result.push(node);
+    } else {
+      const children = filterFieldTree(node.children, keyword);
+      if (children.length > 0) result.push({ ...node, children });
+    }
+  }
+  return result;
+}
+
+/** 叶子：单个配置字段的编辑行 */
+function FieldLeaf({
+  node,
+  value,
+  onValueChange,
+}: {
+  node: FieldTreeNode;
+  value: FieldValue;
+  onValueChange: (v: FieldValue) => void;
+}) {
+  const field = node.field!;
+  return (
+    <div className="grid gap-3 py-4 md:grid-cols-[minmax(180px,1fr)_2fr]">
+      <div className="min-w-0">
+        <Label className="font-mono text-xs">{node.label}</Label>
+        {node.key !== node.label && (
+          <p className="mt-0.5 truncate font-mono text-[10px] text-muted-foreground">
+            {node.key}
+          </p>
+        )}
+        {field.description && (
+          <CardDescription className="mt-1 wrap-break-word">
+            {field.description}
+          </CardDescription>
+        )}
+      </div>
+      <FieldEditor field={field} value={value} onChange={onValueChange} />
+    </div>
+  );
+}
+
+/** 分组：可折叠的嵌套区块 */
+function FieldGroup({
+  node,
+  values,
+  onValueChange,
+  forceOpen,
+}: {
+  node: FieldTreeNode;
+  values: Record<string, FieldValue>;
+  onValueChange: (name: string, v: FieldValue) => void;
+  /** 搜索过滤时强制展开所有分组 */
+  forceOpen: boolean;
+}) {
+  const [open, setOpen] = useState(true);
+  const isOpen = forceOpen || open;
+
+  return (
+    <div>
+      <button
+        type="button"
+        onClick={() => setOpen((o) => !o)}
+        className="flex w-full items-center gap-1.5 py-3 text-left"
+      >
+        {isOpen ? (
+          <ChevronDown className="h-4 w-4 shrink-0 text-muted-foreground" />
+        ) : (
+          <ChevronRight className="h-4 w-4 shrink-0 text-muted-foreground" />
+        )}
+        <span className="text-sm font-medium">{node.label}</span>
+        <span className="truncate font-mono text-xs text-muted-foreground">
+          {node.key}
+        </span>
+      </button>
+      {isOpen && (
+        <div className="ml-2 border-l pl-4">
+          <div className="divide-y">
+            {node.children.map((child) =>
+              child.field ? (
+                <FieldLeaf
+                  key={child.key}
+                  node={child}
+                  value={values[child.key] ?? null}
+                  onValueChange={(v) => onValueChange(child.key, v)}
+                />
+              ) : (
+                <FieldGroup
+                  key={child.key}
+                  node={child}
+                  values={values}
+                  onValueChange={onValueChange}
+                  forceOpen={forceOpen}
+                />
+              ),
+            )}
+          </div>
+        </div>
+      )}
+    </div>
+  );
+}
 
 function parseValue(raw: string, type: string): FieldValue {
   const trimmed = raw.trim();
@@ -56,7 +227,7 @@ function toStrArray(value: FieldValue): string[] {
   return Array.isArray(value) ? value : [];
 }
 
-/** list 字段：条目列表编辑器（每项一行 Input + 删除，底部添加按钮） */
+/** list 字段：条目列表编辑器（逐项可编辑/删除/添加，@dnd-kit 拖拽排序） */
 function ListEditor({
   value,
   onChange,
@@ -65,6 +236,22 @@ function ListEditor({
   onChange: (v: string[]) => void;
 }) {
   const items = toStrArray(value);
+
+  // 指针（鼠标/触屏）拖拽：激活距离 8px 避免与输入框点击/文本选中冲突
+  const sensors = useSensors(
+    useSensor(PointerSensor, {
+      activationConstraint: { distance: 8 },
+    }),
+  );
+
+  function handleDragEnd(event: DragEndEvent) {
+    const { active, over } = event;
+    if (!over) return;
+    const from = Number(active.id);
+    const to = Number(over.id);
+    if (from === to || Number.isNaN(from) || Number.isNaN(to)) return;
+    onChange(arrayMove(items, from, to));
+  }
 
   function update(index: number, text: string) {
     const next = [...items];
@@ -89,6 +276,7 @@ function ListEditor({
     const next = merged.filter((item) => item.trim() !== "");
     if (next.length !== merged.length) onChange(next);
   }
+
   return (
     <div className="space-y-2">
       {items.length === 0 && (
@@ -96,29 +284,92 @@ function ListEditor({
           （空列表）
         </p>
       )}
-      {items.map((item, i) => (
-        <div key={i} className="flex items-center gap-2">
-          <Input
-            value={item}
-            onChange={(e) => update(i, e.target.value)}
-            onBlur={(e) => cleanItem(i, e.target.value)}
-            className="font-mono text-xs"
-            placeholder={`条目 ${i + 1}`}
-          />
-          <Button
-            type="button"
-            variant="ghost"
-            size="icon"
-            className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
-            onClick={() => remove(i)}
-            aria-label={`删除条目 ${i + 1}`}
-          >
-            <X className="h-4 w-4" />
-          </Button>
-        </div>
-      ))}
+      <DndContext
+        sensors={sensors}
+        collisionDetection={closestCenter}
+        onDragEnd={handleDragEnd}
+      >
+        <SortableContext
+          items={items.map((_, i) => String(i))}
+          strategy={verticalListSortingStrategy}
+        >
+          {items.map((item, i) => (
+            <SortableRow
+              key={i}
+              index={i}
+              item={item}
+              onUpdate={update}
+              onRemove={remove}
+              onClean={cleanItem}
+            />
+          ))}
+        </SortableContext>
+      </DndContext>
       <Button type="button" variant="outline" size="sm" onClick={add}>
         <Plus className="mr-1 h-4 w-4" /> 添加条目
+      </Button>
+    </div>
+  );
+}
+
+/** 单行条目：@dnd-kit sortable 行（拖拽手柄 + 输入框 + 删除） */
+function SortableRow({
+  index,
+  item,
+  onUpdate,
+  onRemove,
+  onClean,
+}: {
+  index: number;
+  item: string;
+  onUpdate: (index: number, text: string) => void;
+  onRemove: (index: number) => void;
+  onClean: (index: number, currentText: string) => void;
+}) {
+  const {
+    attributes,
+    listeners,
+    setNodeRef,
+    setActivatorNodeRef,
+    transform,
+    transition,
+    isDragging,
+  } = useSortable({ id: String(index) });
+
+  return (
+    <div
+      ref={setNodeRef}
+      style={{ transform: CSS.Transform.toString(transform), transition }}
+      className={`flex items-center gap-2 rounded-md ${
+        isDragging ? "relative z-10 bg-muted/80 ring-1 ring-primary" : ""
+      }`}
+    >
+      <button
+        type="button"
+        ref={setActivatorNodeRef}
+        {...attributes}
+        {...listeners}
+        className="shrink-0 cursor-grab touch-none rounded p-0.5 text-muted-foreground hover:text-foreground active:cursor-grabbing"
+        aria-label={`拖动排序条目 ${index + 1}`}
+      >
+        <GripVertical className="h-4 w-4" />
+      </button>
+      <Input
+        value={item}
+        onChange={(e) => onUpdate(index, e.target.value)}
+        onBlur={(e) => onClean(index, e.target.value)}
+        className="font-mono text-xs"
+        placeholder={`条目 ${index + 1}`}
+      />
+      <Button
+        type="button"
+        variant="ghost"
+        size="icon"
+        className="h-8 w-8 shrink-0 text-muted-foreground hover:text-destructive"
+        onClick={() => onRemove(index)}
+        aria-label={`删除条目 ${index + 1}`}
+      >
+        <X className="h-4 w-4" />
       </Button>
     </div>
   );
@@ -216,6 +467,7 @@ export function ConfeditEditorPage() {
   const queryClient = useQueryClient();
   const [draft, setDraft] = useState<Record<string, FieldValue>>({});
   const [changed, setChanged] = useState(false);
+  const [keyword, setKeyword] = useState("");
 
   const { data, isLoading, error } = useQuery({
     queryKey: ["confedit-schema", owner_name],
@@ -244,12 +496,46 @@ export function ConfeditEditorPage() {
     return values;
   }, [schema]);
 
+  /** 展平字段 → 嵌套树（按 "." 分层展示） */
+  const tree = useMemo(() => buildFieldTree(schema?.fields ?? []), [schema]);
+  const visibleTree = useMemo(
+    () => filterFieldTree(tree, keyword),
+    [tree, keyword],
+  );
+
   const values = changed ? draft : initialValues;
 
   const setValue = (name: string, v: FieldValue) => {
     setChanged(true);
-    setDraft((d) => ({ ...d, [name]: v }));
+    setDraft((d) => {
+      // 首次修改以初始值为底，避免切换 draft 时其余字段被置空
+      const base = Object.keys(d).length > 0 ? d : initialValues;
+      return { ...base, [name]: v };
+    });
   };
+
+  // 未保存修改时拦截 SPA 内部导航（侧边栏跳转等），浏览器原生 confirm 确认
+  const blocker = useBlocker(changed);
+  useEffect(() => {
+    if (blocker.state === "blocked") {
+      if (window.confirm("有未保存的修改，确定离开吗？")) {
+        blocker.proceed();
+      } else {
+        blocker.reset();
+      }
+    }
+  }, [blocker]);
+
+  // 未保存修改时拦截浏览器刷新/关闭（原生对话框，样式由浏览器决定）
+  useEffect(() => {
+    if (!changed) return;
+    const handler = (e: BeforeUnloadEvent) => {
+      e.preventDefault();
+      e.returnValue = "";
+    };
+    window.addEventListener("beforeunload", handler);
+    return () => window.removeEventListener("beforeunload", handler);
+  }, [changed]);
 
   /** 提交前清理：所有 list 数组字段过滤空条目 */
   function cleanForSubmit(
@@ -323,32 +609,47 @@ export function ConfeditEditorPage() {
       </div>
 
       <Card>
-        <CardContent className="divide-y">
-          {schema.fields.length === 0 && (
+        <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0 pb-2">
+          <CardTitle className="text-base">配置项</CardTitle>
+          <Input
+            className="h-9 w-64"
+            placeholder="搜索配置项…"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+          />
+        </CardHeader>
+        <CardContent>
+          {schema.fields.length === 0 ? (
             <p className="py-8 text-center text-sm text-muted-foreground">
               该插件没有可配置字段
             </p>
-          )}
-          {schema.fields.map((field) => (
-            <div
-              key={field.name}
-              className="grid gap-3 py-4 md:grid-cols-[minmax(180px,1fr)_2fr]"
-            >
-              <div className="min-w-0">
-                <Label className="font-mono text-xs">{field.name}</Label>
-                {field.description && (
-                  <CardDescription className="mt-1 wrap-break-word">
-                    {field.description}
-                  </CardDescription>
-                )}
-              </div>
-              <FieldEditor
-                field={field}
-                value={values[field.name] ?? null}
-                onChange={(v) => setValue(field.name, v)}
-              />
+          ) : visibleTree.length === 0 ? (
+            <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+              <SearchX className="h-8 w-8" />
+              <p className="text-sm">没有匹配的配置项</p>
             </div>
-          ))}
+          ) : (
+            <div className="divide-y">
+              {visibleTree.map((node) =>
+                node.field ? (
+                  <FieldLeaf
+                    key={node.key}
+                    node={node}
+                    value={values[node.key] ?? null}
+                    onValueChange={(v) => setValue(node.key, v)}
+                  />
+                ) : (
+                  <FieldGroup
+                    key={node.key}
+                    node={node}
+                    values={values}
+                    onValueChange={setValue}
+                    forceOpen={!!keyword.trim()}
+                  />
+                ),
+              )}
+            </div>
+          )}
         </CardContent>
       </Card>
 

--- a/frontend/src/pages/system/confedit.tsx
+++ b/frontend/src/pages/system/confedit.tsx
@@ -1,12 +1,16 @@
+import { useMemo, useState } from "react";
 import { useQuery } from "@tanstack/react-query";
 import { useNavigate } from "react-router-dom";
+import { SearchX } from "lucide-react";
 import { api } from "@/lib/api";
 import type { ConfeditListData } from "@/lib/types";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Input } from "@/components/ui/input";
 
 export function ConfeditPage() {
   const navigate = useNavigate();
+  const [keyword, setKeyword] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: ["confedit-list"],
@@ -15,6 +19,16 @@ export function ConfeditPage() {
 
   const items = data?.data.configs ?? [];
 
+  const filtered = useMemo(() => {
+    const k = keyword.trim().toLowerCase();
+    if (!k) return items;
+    return items.filter(
+      (c) =>
+        c.name.toLowerCase().includes(k) ||
+        c.class_name.toLowerCase().includes(k),
+    );
+  }, [items, keyword]);
+
   return (
     <div className="space-y-6">
       <div>
@@ -22,8 +36,14 @@ export function ConfeditPage() {
         <p className="text-sm text-muted-foreground">编辑各插件的配置</p>
       </div>
       <Card>
-        <CardHeader>
+        <CardHeader className="flex flex-row items-center justify-between gap-4 space-y-0">
           <CardTitle className="text-base">可配置插件</CardTitle>
+          <Input
+            className="h-9 w-64"
+            placeholder="搜索插件名或类名…"
+            value={keyword}
+            onChange={(e) => setKeyword(e.target.value)}
+          />
         </CardHeader>
         <CardContent>
           {isLoading ? (
@@ -31,13 +51,20 @@ export function ConfeditPage() {
               <div className="h-10 animate-pulse rounded-md bg-muted" />
               <div className="h-10 animate-pulse rounded-md bg-muted" />
             </div>
-          ) : items.length === 0 ? (
-            <p className="py-8 text-center text-sm text-muted-foreground">
-              没有可配置的插件
-            </p>
+          ) : filtered.length === 0 ? (
+            items.length === 0 ? (
+              <p className="py-8 text-center text-sm text-muted-foreground">
+                没有可配置的插件
+              </p>
+            ) : (
+              <div className="flex flex-col items-center gap-2 py-8 text-muted-foreground">
+                <SearchX className="h-8 w-8" />
+                <p className="text-sm">没有匹配的插件</p>
+              </div>
+            )
           ) : (
             <div className="divide-y rounded-md border">
-              {items.map((c) => (
+              {filtered.map((c) => (
                 <div
                   key={c.name}
                   className="flex items-center gap-3 px-4 py-3 text-sm"

--- a/frontend/src/pages/user/perm-group.tsx
+++ b/frontend/src/pages/user/perm-group.tsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import type { PermissionsDetailData } from "@/lib/types";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { PermissionEditor } from "@/components/shared/PermissionEditor";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Card,
@@ -18,7 +17,6 @@ import {
 export function PermGroupDetailPage() {
   const { name } = useParams<{ name: string }>();
   const navigate = useNavigate();
-  const [permissions, setPermissions] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: ["perm-group", name],
@@ -30,7 +28,7 @@ export function PermGroupDetailPage() {
   });
 
   const saveMutation = useMutation({
-    mutationFn: () =>
+    mutationFn: (permissions: string) =>
       api.post(`/api/permissions/groups/${encodeURIComponent(name ?? "")}`, {
         permissions,
       }),
@@ -60,30 +58,21 @@ export function PermGroupDetailPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">权限字符串</CardTitle>
+          <CardTitle className="text-base">权限列表</CardTitle>
           <CardDescription>
-            每行一条权限，格式如 node.permission
+            每行一条权限：节点路径 + 允许/拒绝开关
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Textarea
-            className="min-h-60 font-mono text-sm"
-            value={permissions || data.data.permissions}
-            onChange={(e) => setPermissions(e.target.value)}
-            spellCheck={false}
+          <PermissionEditor
+            key={name}
+            initial={data.data.permissions}
+            onSubmit={(permissions) => saveMutation.mutate(permissions)}
+            submitting={saveMutation.isPending}
           />
-          <div className="flex justify-between">
-            <Button
-              variant="outline"
-              onClick={() => navigate("/permissions/groups")}
-            >
+          <div className="flex justify-start">
+            <Button variant="outline" onClick={() => navigate(-1)}>
               返回
-            </Button>
-            <Button
-              onClick={() => saveMutation.mutate()}
-              disabled={saveMutation.isPending}
-            >
-              {saveMutation.isPending ? "保存中…" : "保存"}
             </Button>
           </div>
         </CardContent>

--- a/frontend/src/pages/user/user-permission.tsx
+++ b/frontend/src/pages/user/user-permission.tsx
@@ -1,11 +1,10 @@
-import { useState } from "react";
 import { useMutation, useQuery } from "@tanstack/react-query";
 import { useNavigate, useParams } from "react-router-dom";
 import { toast } from "sonner";
 import { api } from "@/lib/api";
 import type { PermissionsDetailData } from "@/lib/types";
 import { Button } from "@/components/ui/button";
-import { Textarea } from "@/components/ui/textarea";
+import { PermissionEditor } from "@/components/shared/PermissionEditor";
 import { Skeleton } from "@/components/ui/skeleton";
 import {
   Card,
@@ -26,7 +25,6 @@ function PermissionScope({
   endpoint: string;
 }) {
   const navigate = useNavigate();
-  const [permissions, setPermissions] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: [endpoint, id],
@@ -35,7 +33,7 @@ function PermissionScope({
   });
 
   const saveMutation = useMutation({
-    mutationFn: () => api.post(endpoint, { permissions }),
+    mutationFn: (permissions: string) => api.post(endpoint, { permissions }),
     onSuccess: (res) => toast.success(res.message),
     onError: (e: Error) => toast.error(e.message),
   });
@@ -62,27 +60,21 @@ function PermissionScope({
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">权限字符串</CardTitle>
+          <CardTitle className="text-base">权限列表</CardTitle>
           <CardDescription>
-            每行一条权限，格式如 node.permission
+            每行一条权限：节点路径 + 允许/拒绝开关
           </CardDescription>
         </CardHeader>
         <CardContent className="space-y-4">
-          <Textarea
-            className="min-h-60 font-mono text-sm"
-            value={permissions || data.data.permissions}
-            onChange={(e) => setPermissions(e.target.value)}
-            spellCheck={false}
+          <PermissionEditor
+            key={id}
+            initial={data.data.permissions}
+            onSubmit={(permissions) => saveMutation.mutate(permissions)}
+            submitting={saveMutation.isPending}
           />
-          <div className="flex justify-between">
+          <div className="flex justify-start">
             <Button variant="outline" onClick={() => navigate(-1)}>
               返回
-            </Button>
-            <Button
-              onClick={() => saveMutation.mutate()}
-              disabled={saveMutation.isPending}
-            >
-              {saveMutation.isPending ? "保存中…" : "保存"}
             </Button>
           </div>
         </CardContent>

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.6.0"
+version = "1.6.1"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -247,7 +247,7 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "1.6.0"
+version = "1.6.1"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

Enhance the WebUI with improved configuration editing, prompt management, permissions editing, navigation, and version display.

New Features:
- Introduce nested, searchable configuration field groups with collapsible sections in the config editor.
- Add drag-and-drop reordering for list-type configuration fields using a sortable UI.
- Provide a dedicated forgot-password guidance page linked from the login screen.
- Display the Amrita version in the sidebar using data returned from the backend menu API.
- Expose static assets under /static/ through the frontend proxy.

Bug Fixes:
- Prevent losing untouched configuration values when the first change is made in the config editor by seeding the draft state from initial values.
- Ensure delete confirmation dialogs for prompts close immediately after successful deletion.

Enhancements:
- Refactor prompt management into separate tabs for group and private prompts, each with its own creation dialog and simplified table columns.
- Replace raw textarea-based permission editing with a structured PermissionEditor component for both user and group permissions.
- Add search filters and empty-state indicators for configurable plugins and configuration fields.
- Add navigation blocking and beforeunload protection when there are unsaved changes in the configuration editor.
- Switch to React Router data router (createBrowserRouter) to support advanced routing features like useBlocker.
- Adjust navigation in permission pages to use back navigation instead of fixed routes.
- Rework the login flow routing so unauthenticated users can access both login and forgot-password routes.

Build:
- Enable the frontend typecheck step in CI workflows.
- Add @dnd-kit dependencies for drag-and-drop functionality in the frontend.

CI:
- Enable TypeScript type checking for the frontend in CI and PR workflows.

Chores:
- Bump the Amrita project version from 1.6.0 to 1.6.1 and extend MenuData to include the version field.