### PR TITLE
Fix chat toggle and sync default model preset with config

### DIFF
--- a/amrita/plugins/chat/check_rule.py
+++ b/amrita/plugins/chat/check_rule.py
@@ -40,7 +40,12 @@ class FakeEvent(Event):
         return str(self.user_id)
 
 
-async def is_bot_enabled(event: Event) -> bool:
+async def is_bot_globally_enabled(event: Event) -> bool:
+    """仅检查全局开关与功能开关，不检查每群的 enable 标记。
+
+    供聊天开关（/chat）等命令使用，避免 /chat off 关闭群聊后
+    is_bot_enabled 失效，导致无法再次执行 /chat on。
+    """
     gid = getattr(event, "group_id", None)
     is_in_group = gid is not None
     if not config_manager.config.enable:
@@ -53,6 +58,13 @@ async def is_bot_enabled(event: Event) -> bool:
         bots = nonebot.get_bots()
         if event.get_user_id() in bots:
             return False
+    return True
+
+
+async def is_bot_enabled(event: Event) -> bool:
+    gid = getattr(event, "group_id", None)
+    if not await is_bot_globally_enabled(event):
+        return False
     if gid is not None:
         data = await CGDR().get_group_config(
             gid,

--- a/amrita/plugins/chat/matcher_manager.py
+++ b/amrita/plugins/chat/matcher_manager.py
@@ -10,6 +10,7 @@ from ..menu.models import MatcherData
 from .check_rule import (
     is_bot_admin,
     is_bot_enabled,
+    is_bot_globally_enabled,
     is_group_admin,
     is_group_admin_if_is_in_group,
     should_respond_with_usage_check,
@@ -29,6 +30,10 @@ from .handlers.session_cmd import session
 
 # 创建基础匹配器组，所有匹配器都需满足is_bot_enabled规则
 base_matcher = MatcherGroup(rule=is_bot_enabled)
+
+# 聊天开关匹配器组：仅检查全局开关，不受每群 enable 标记影响，
+# 避免 /chat off 关闭群聊后无法再次执行 /chat on
+chat_switch_matcher = MatcherGroup(rule=is_bot_globally_enabled)
 
 # 添加通知事件处理器
 base_matcher.on_notice(
@@ -118,7 +123,7 @@ base_matcher.on_command(
 ).append_handler(session)
 
 # 聊天开关域
-base_matcher.on_command(
+chat_switch_matcher.on_command(
     "chat",
     aliases={"聊天开关", "chat_switch"},
     priority=10,
@@ -146,7 +151,11 @@ base_matcher.on_command(
         name="调试模式",
         description="调试模式开关（on/off/status）",
         show_if="lp.admin",
-        usage="/debug <on|off|status>",
+        usage=[
+            "/debug on — 开启调试",
+            "/debug off — 关闭调试",
+            "/debug status — 查看状态",
+        ],
     ).model_dump(),
 ).append_handler(debug_switchs)
 
@@ -159,7 +168,11 @@ base_matcher.on_command(
     state=MatcherData(
         name="用量统计",
         description="查看今日AI用量统计",
-        usage="/insights [global|top10 <--group|private|all>]]",
+        usage=[
+            "/insights — 查看今日用量",
+            "/insights global — 全局用量",
+            "/insights top10 <--group|private|all> — Top10 排名",
+        ],
     ).model_dump(),
 ).append_handler(insights)
 
@@ -172,7 +185,13 @@ base_matcher.on_command(
         name="mcp",
         description="管理MCP服务",
         show_if="lp.admin",
-        usage="/mcp <stats [-d|--details];add <server_script>;del <server_script>;reload>",
+        usage=[
+            "/mcp stats [-d|--details] — 服务统计",
+            "/mcp add <server_script> — 添加服务",
+            "/mcp del <server_script> — 删除服务",
+            "/mcp reload — 重载服务",
+            "/mcp deep-reload — 深度重载",
+        ],
     ).model_dump(),
 ).append_handler(mcp_command)
 

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -58,7 +58,21 @@ class PresetStore:
             self._loaded.append(lp)
             PresetManager().add_preset(model_preset)
 
+        self._sync_default_preset()
+
         return [lp.preset for lp in self._loaded]
+
+    def _sync_default_preset(self) -> None:
+        """把配置选中的预设同步为 PresetManager 的默认预设。
+
+        在此项目中，选中的预设只有一个：default 是且仅能是 config 已选中的
+        预设（config.default_preset）。若未显式设置，PresetManager
+        的 get_default_preset() 会随机挑选一个预设，导致运行时模型随机漂移
+        （未预期行为）。每次加载预设后都重新指定，与配置保持一致。
+        """
+        from .config import config_manager
+
+        PresetManager().set_default_preset(config_manager.config.default_preset)
 
     async def find(self, name: str, *, cache: bool = False) -> ModelPreset | None:
         """按名查找预设"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.6.3"
+version = "1.6.4"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "1.6.2"
+version = "1.6.4"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },


### PR DESCRIPTION
## Summary by Sourcery

Fix chat toggle recovery and synchronize runtime model selection with the configured default preset.

Bug Fixes:
- Allow the chat toggle command to re-enable chat after it has been disabled for a group.
- Ensure the configured default model preset is consistently selected instead of allowing runtime random selection.

Enhancements:
- Present debug, usage statistics, and MCP command usage as clearer individual entries.

Build:
- Bump the project version from 1.6.3 to 1.6.4.