### PR TITLE
refactor(chat): decouple preset handling from global PresetManager

### DIFF
--- a/amrita/plugins/chat/backends.py
+++ b/amrita/plugins/chat/backends.py
@@ -35,7 +35,14 @@ class ChatMemoryBackend(MemoryBackend):
 
 
 class NoopAbilityBackend(AbilityBackend):
-    """空能力后端占位符：本插件的全部能力 fetch 均由 ``DatabackendOptions`` 跳过。"""
+    """能力后端：构建本插件的实际能力容器。
+
+    其中 ``load_presets`` 构建并返回一个以配置选中预设为默认预设的
+    ``MultiPresetManager``，由 Core 在 ``LOAD_STATE`` 节点抓取，从而
+    彻底脱离全局单例 ``PresetManager``（其默认预设受热重载 / 脏状态影响，
+    且 Core 已改为 FailFast）。其余能力（MCP / tools / ability）由
+    ``DatabackendOptions`` 决定是否抓取。
+    """
 
     async def load_ability_all(self, session_id: str) -> AbilityContext:
         del session_id
@@ -51,4 +58,10 @@ class NoopAbilityBackend(AbilityBackend):
 
     async def load_presets(self, session_id: str) -> MultiPresetManager:
         del session_id
-        return MultiPresetManager()
+        # 延迟导入避免与 config 模块产生循环依赖
+        from .config import config_manager
+
+        manager = MultiPresetManager()
+        # 配置选中的预设即默认预设；set_default_preset 会自动登记进管理器
+        manager.set_default_preset(config_manager.config.default_preset)
+        return manager

--- a/amrita/plugins/chat/handlers/chat.py
+++ b/amrita/plugins/chat/handlers/chat.py
@@ -6,7 +6,6 @@ from asyncio import CancelledError
 from datetime import datetime
 
 from amrita_core import (
-    PresetManager,
     TextContent,
     UniResponseUsage,
     debug_log,
@@ -198,7 +197,7 @@ async def get_user_role(bot: Bot, group_id: int, user_id: int) -> str:
     return role_str
 
 
-def synthesize_message_to_msg(
+async def synthesize_message_to_msg(
     event: MessageEvent,
     role: str,
     user_name: str,
@@ -221,20 +220,14 @@ def synthesize_message_to_msg(
     Returns:
         转换后的消息内容
     """
-    is_multimodal: bool = (
-        any(
-            (
-                (PresetManager().get_preset(preset)).config.multimodal
-                if preset != "default"
-                else ConfigManager().config.default_preset.config.multimodal
-            )
-            for preset in [
-                config_manager.config.preset,
-                *config_manager.config.preset_extension.backup_preset_list,
-            ]
-        )
-        # or len(config_manager.config.preset_extension.multi_modal_preset_list) > 0
-    )
+    presets = [
+        await config_manager.get_preset(preset)
+        for preset in [
+            config_manager.config.preset,
+            *config_manager.config.preset_extension.backup_preset_list,
+        ]
+    ]
+    is_multimodal: bool = any(p.config.multimodal for p in presets)
 
     if config_manager.config.parse_segments:
         if config_manager.config.function.message_type == "xml":
@@ -339,7 +332,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         debug_log("处理私聊消息")
         user_name = await get_friend_name(event.user_id, bot=bot)
     role = await get_user_role(bot, event.group_id, event.user_id) if is_group else ""
-    content = synthesize_message_to_msg(
+    content = await synthesize_message_to_msg(
         event, role, str(user_name), str(event.user_id), content
     )
     if isinstance(content, list):
@@ -388,7 +381,6 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         backend_options=DatabackendOptions(
             skip_mcp_fetch=True,
             skip_tools_fetch=True,
-            skip_presets_fetch=True,
         ),
     )
 

--- a/amrita/plugins/chat/handlers/model.py
+++ b/amrita/plugins/chat/handlers/model.py
@@ -6,7 +6,8 @@ import asyncio
 import json
 
 from aiologic import Lock
-from amrita_core import PresetManager, PresetReport
+from amrita_core import PresetReport
+from amrita_core.preset import MultiPresetManager
 from nonebot.adapters.onebot.v11 import Bot, Message, MessageEvent, MessageSegment
 from nonebot.matcher import Matcher
 from nonebot.params import CommandArg
@@ -42,7 +43,6 @@ async def model_switch(
         if model.name == name:
             config_manager.ins_config.preset = model.name
             await config_manager.save_config()
-            PresetManager().set_default_preset(model)
             await matcher.finish(f"✅ 已切换到：{model.name}（{model.model}）")
     await matcher.finish(f"未找到模型 {name}，请输入 /model list 查看可用模型。")
 
@@ -66,7 +66,7 @@ async def model_test(
     event: MessageEvent, matcher: Matcher, bot: Bot, name: str, detailed: bool
 ) -> None:
     """测试指定模型（不指定则测试全部）"""
-    pm = PresetManager()
+    pm = MultiPresetManager()
     if name:
         try:
             presets = [await config_manager.get_preset(name)]

--- a/amrita/plugins/chat/hooks/preset_switch.py
+++ b/amrita/plugins/chat/hooks/preset_switch.py
@@ -1,4 +1,3 @@
-from amrita_core import PresetManager
 from amrita_core.hook.event import FallbackContext
 from amrita_core.hook.on import on_preset_fallback
 
@@ -11,6 +10,6 @@ async def _(ctx: FallbackContext):
     count = ctx.term
     if count > len(config.preset_extension.backup_preset_list):
         ctx.fail("No more preset available!")
-    ctx.preset = PresetManager().get_preset(
+    ctx.preset = await dm.get_preset(
         config.preset_extension.backup_preset_list[count - 1]
     )

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -6,7 +6,7 @@ from dataclasses import dataclass
 from pathlib import Path
 from typing import Any
 
-from amrita_core import ModelPreset, PresetManager
+from amrita_core import ModelPreset
 from nonebot import logger
 from nonebot_plugin_uniconf.manager import replace_env_vars
 
@@ -41,12 +41,11 @@ class PresetStore:
                 )
 
     async def load_all(self, *, cache: bool = False) -> list[ModelPreset]:
-        """加载全部预设并注册到 PresetManager"""
+        """加载全部预设（不依赖全局 PresetManager 单例）"""
         if cache and self._loaded:
             return [lp.preset for lp in self._loaded]
         self._loaded.clear()
         self._by_name.clear()
-        PresetManager()._presets.clear()
         for path in self.models_dir.glob("*.json"):
             model_data = ModelPreset.load(path).model_dump()
             preset_data = replace_env_vars(model_data)
@@ -56,23 +55,8 @@ class PresetStore:
             lp = LoadedPreset(model_preset, path.stem, path)
             self._by_name[model_preset.name] = lp
             self._loaded.append(lp)
-            PresetManager().add_preset(model_preset)
-
-        self._sync_default_preset()
 
         return [lp.preset for lp in self._loaded]
-
-    def _sync_default_preset(self) -> None:
-        """把配置选中的预设同步为 PresetManager 的默认预设。
-
-        在此项目中，选中的预设只有一个：default 是且仅能是 config 已选中的
-        预设（config.default_preset）。若未显式设置，PresetManager
-        的 get_default_preset() 会随机挑选一个预设，导致运行时模型随机漂移
-        （未预期行为）。每次加载预设后都重新指定，与配置保持一致。
-        """
-        from .config import config_manager
-
-        PresetManager().set_default_preset(config_manager.config.default_preset)
 
     async def find(self, name: str, *, cache: bool = False) -> ModelPreset | None:
         """按名查找预设"""

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.6.4"
+version = "1.6.5"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -338,7 +338,7 @@ dev = [
 
 [[package]]
 name = "amrita-core"
-version = "0.13.4"
+version = "0.13.6"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "aiofiles" },
@@ -354,9 +354,9 @@ dependencies = [
     { name = "pydantic" },
     { name = "pytz" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/d6/97/1ce54906fb81edad22f8e84ffb3660fb45a16c0c96432b8d82a6fd0fa49f/amrita_core-0.13.4.tar.gz", hash = "sha256:da58c2d062ab18cef1d4bcfe639754a72b55f42ceccc7281a7e10da7e3797348", size = 181451, upload-time = "2026-08-15T08:23:41.452Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/3e/23/b44dbaf4af05cb4daeb46b7dc7145f9b7a49f1f2da770343d653581031d3/amrita_core-0.13.6.tar.gz", hash = "sha256:a03178cdc646c7d98dea8b4c3d0bfde0aff1bce981a2f90194310d52199da9ef", size = 184896, upload-time = "2026-08-19T10:28:30.994Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/38/fe/50bcde64076849668ce922bb2d5466b4f608ca63bcaee22f64094f672a49/amrita_core-0.13.4-py3-none-any.whl", hash = "sha256:8f9ab7ba34954934535bf6893f79f9aadde670567384f9005fbf07f8ff3fc7e1", size = 149762, upload-time = "2026-08-15T08:23:40.068Z" },
+    { url = "https://files.pythonhosted.org/packages/d0/88/051e8625aded024e0daf56aa8e306abece434a5eb2da93bd41404342e37c/amrita_core-0.13.6-py3-none-any.whl", hash = "sha256:95a70a34134f12ebee268e34e4e40a19509655de5e1b1e498b82ef5c217f26d4", size = 151380, upload-time = "2026-08-19T10:28:29.736Z" },
 ]
 
 [package.optional-dependencies]
@@ -883,7 +883,7 @@ wheels = [
 
 [[package]]
 name = "cyclopts"
-version = "4.22.5"
+version = "4.23.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "attrs" },
@@ -893,9 +893,9 @@ dependencies = [
     { name = "tomli", marker = "python_full_version < '3.11'" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/be/05/689617b7e86503417c172f577d791524cb13b9697303d5d44409a971ba10/cyclopts-4.22.5.tar.gz", hash = "sha256:94044506317462cad90fb01a917dadce1f48a0915ba3605dc8d178dea1229e24", size = 195144, upload-time = "2026-08-04T13:53:00.303Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5e/62/1b160d5e8c20174392a3a5e3e7e6542e02e6f6922b35ba0962829a6b5c90/cyclopts-4.23.0.tar.gz", hash = "sha256:2f764bbd90f1888073971c09576f90e594f80353588e10aa615b7d59bc009821", size = 195257, upload-time = "2026-08-17T19:44:21.218Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/83/58/bcab9c33fb7a25a1f5970f357c5b19729bc81d50615d2f737b20c4255909/cyclopts-4.22.5-py3-none-any.whl", hash = "sha256:cf9ce285836053d156730ea4ea0ad0c75cf63beb3f3d8edf222a795bc57666ab", size = 234557, upload-time = "2026-08-04T13:52:58.509Z" },
+    { url = "https://files.pythonhosted.org/packages/32/1f/70aeb4f9a420cb62726d943b0d893c2bf9e9ab9c81a93f7542d3beb5d69c/cyclopts-4.23.0-py3-none-any.whl", hash = "sha256:1581758c5b9982c3b2ae7df6d87243e3a6fc3265ea621f96caeb349b6fa43ad2", size = 234671, upload-time = "2026-08-17T19:44:19.604Z" },
 ]
 
 [[package]]
@@ -1195,11 +1195,11 @@ wheels = [
 
 [[package]]
 name = "griffelib"
-version = "2.1.0"
+version = "2.2.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/33/e4/8d187ea29c2e30b3a09505c567513077d6117861bde1fbd997a167f262ec/griffelib-2.1.0.tar.gz", hash = "sha256:762a186d2c6fd6794d4ea20d428d597ffb857cb56b66421651cbba15bdd5e813", size = 216234, upload-time = "2026-06-19T12:05:42.278Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f0/b4/a767e91c606deefc447a96eaf59edd77397960b1d677dffd833ee8449831/griffelib-2.2.0.tar.gz", hash = "sha256:e1bc36fe9cd21d4b6b659b456346755e4cfdc5676c0a5214083126ee12612b3c", size = 227048, upload-time = "2026-08-16T14:04:58.383Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e4/d3/5268aeabf2ad82658c4e2ff3a060648d0f02f3926cb53247c0e4d0dab49e/griffelib-2.1.0-py3-none-any.whl", hash = "sha256:cc7b3d2d2865ad0b909fcc38086e3f554b5ea7acbaa7bbb7ecaa3f5dfb7d9f00", size = 142560, upload-time = "2026-06-19T12:05:38.742Z" },
+    { url = "https://files.pythonhosted.org/packages/f6/b6/f65ac785d4ac90dcf7c831ac6256f5dd4a19780f4e1575b2c0d6eeebe319/griffelib-2.2.0-py3-none-any.whl", hash = "sha256:d71c3bc2bbed9f958488634fe788b843a9f705d6d2838ca32cd6c25eeb64dfc4", size = 166779, upload-time = "2026-08-16T14:04:54.365Z" },
 ]
 
 [[package]]
@@ -1226,15 +1226,15 @@ wheels = [
 
 [[package]]
 name = "httpcore2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "h11", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
     { name = "truststore", marker = "python_full_version < '3.12' or sys_platform != 'emscripten'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/a9/83/a896fc59940fc5a6e2aff3a4be1d92fa890112936803b331cae75a993c34/httpcore2-2.10.0.tar.gz", hash = "sha256:13c0cc3d1919d4f28457f60cd2c2abe04113a8af184ccf1142811beba936f9dc", size = 67427, upload-time = "2026-08-09T09:11:32.123Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/be/ad/f4f0e57345f1870f3e8cb624e058d7eca6e5a27d33bcc3311d9b618734cd/httpcore2-2.12.0.tar.gz", hash = "sha256:9293522bba0aa7c4c8e9e3f040c16575bd8868e155a77fa30c7a9085a5eae648", size = 67548, upload-time = "2026-08-18T13:22:08.211Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/e5/4f/d149104195a35e2853a2fc203a8e3477747e58c80e17dda686dace174383/httpcore2-2.10.0-py3-none-any.whl", hash = "sha256:7df06cfb34070cae4f7c89be69dc1095eca138e9704ceffb98d25c1912ab6f01", size = 83000, upload-time = "2026-08-09T09:11:29.555Z" },
+    { url = "https://files.pythonhosted.org/packages/d2/74/d370e55600d9bcfa0d9794b0166126d49291a3d2b20c268fc98c453a4948/httpcore2-2.12.0-py3-none-any.whl", hash = "sha256:7e04258ce01013d7d615e5b910a3b27fac937d7a95038227e79652b4ba3b4ceb", size = 83074, upload-time = "2026-08-18T13:22:05.854Z" },
 ]
 
 [[package]]
@@ -1299,7 +1299,7 @@ wheels = [
 
 [[package]]
 name = "httpx2"
-version = "2.10.0"
+version = "2.12.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio", marker = "sys_platform != 'emscripten'" },
@@ -1309,9 +1309,9 @@ dependencies = [
     { name = "truststore", marker = "sys_platform != 'emscripten'" },
     { name = "typing-extensions", marker = "python_full_version < '3.13'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/bd/3d/f9a8c07a3884f3e5b26205e8436a18b3af61c5d53192c3bea235574dbbec/httpx2-2.10.0.tar.gz", hash = "sha256:8741d7329fe2c7885fc9ceb61c8217acfb87a85f75723714b89ebf7ad7196338", size = 98749, upload-time = "2026-08-09T09:11:33.24Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/7f/f8/579a8b51e42e38ee32647df9f08aa25643ae788e275cc625b199829c4671/httpx2-2.12.0.tar.gz", hash = "sha256:7631fe9887a8a2275f4a2540e053aa670fcc50742864a9ae7c66e609fdcf12cf", size = 100040, upload-time = "2026-08-18T13:22:09.086Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/b9/6d/a637d52449d98a6892d9a4dc0262587afdb6a66f201871842dce5a97b1c1/httpx2-2.10.0-py3-none-any.whl", hash = "sha256:5e3194a432701e1cc6f69a8b1b2fa199ef907013fede8d9a09a2c5b7b8141a18", size = 94355, upload-time = "2026-08-09T09:11:30.882Z" },
+    { url = "https://files.pythonhosted.org/packages/c8/95/411ba65569158e862368917aaf56597f3e5fa3b91b0502919638465a08f3/httpx2-2.12.0-py3-none-any.whl", hash = "sha256:cc8b6eecb8661c146b8f89a60e97456ee086e91a784ed31ac450c3a9e613dd36", size = 95427, upload-time = "2026-08-18T13:22:06.834Z" },
 ]
 
 [[package]]
@@ -1325,11 +1325,11 @@ wheels = [
 
 [[package]]
 name = "idna"
-version = "3.18"
+version = "3.19"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/cd/63/9496c57188a2ee585e0f1db071d75089a11e98aa86eb99d9d7618fc1edce/idna-3.18.tar.gz", hash = "sha256:ffb385a7e039654cef1ab9ef32c6fafe283c0c0467bba1d9029738ce4a14a848", size = 196711, upload-time = "2026-06-02T14:34:07.794Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/5f/f7/abb373e5757eaec4b922b92f97ec8d6d7e057cf06778247604fbc4e7c3f3/idna-3.19.tar.gz", hash = "sha256:5e0811a4383b21dc5838069f801c4fb62113b7447663d2530d2bd6e77b49bf15", size = 215237, upload-time = "2026-08-18T05:14:24.27Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/1e/5e/d4e9f1a599fb8e573b7b87160658329fbf28d19eac2718f51fc3def3aa5a/idna-3.18-py3-none-any.whl", hash = "sha256:7f952cbe720b688055e3f87de14f5c3e5fdaa8bc3928985c4077ca689de849a2", size = 65455, upload-time = "2026-06-02T14:34:06.319Z" },
+    { url = "https://files.pythonhosted.org/packages/57/b0/0e52c878c53f245edd3a11020f20979b3f490f245af532c7cae3027754b5/idna-3.19-py3-none-any.whl", hash = "sha256:815e7be7a7806d54abb586dc943addc79e8b2ee16915059658cbeff4b1b43bf4", size = 68550, upload-time = "2026-08-18T05:14:22.343Z" },
 ]
 
 [[package]]
@@ -2082,7 +2082,7 @@ wheels = [
 
 [[package]]
 name = "openai"
-version = "3.1.0"
+version = "3.3.0"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "anyio" },
@@ -2091,12 +2091,11 @@ dependencies = [
     { name = "jiter" },
     { name = "pydantic" },
     { name = "sniffio" },
-    { name = "tqdm" },
     { name = "typing-extensions" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/58/9b/d45911bf9abfc5a754d800d79fe56e4dcf6e7b679d6ff4b7e9689b56bc02/openai-3.1.0.tar.gz", hash = "sha256:3ae7190da63f718727f9c525740d3f713e85553d2bf1d0cc9247346bd9063a4d", size = 1131016, upload-time = "2026-08-14T23:49:46.325Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/e6/6c/670271205379061112bf5ed900b78a68e21bf11733de829772c5322f92aa/openai-3.3.0.tar.gz", hash = "sha256:28f904a9fbff15288e9dd67bc0f7020d4f576d37786383a480db02fe5d8139d3", size = 1166178, upload-time = "2026-08-18T21:17:53.419Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/d3/45/84b9e909968c0f4c3112a828bba9aa8be6a5ee322fcb3d781145ee53d88e/openai-3.1.0-py3-none-any.whl", hash = "sha256:f06d5a5c8d06a0aead3a67d33fe5a3c3c31540a0f7a8017b02ba8cd99bc5c736", size = 1670762, upload-time = "2026-08-14T23:49:43.998Z" },
+    { url = "https://files.pythonhosted.org/packages/82/83/d44980712bf51dddaca090cd772b3102e75377ddac877eaa4b2cb58d886a/openai-3.3.0-py3-none-any.whl", hash = "sha256:ded6b2112e6d299c7a2573ff6f165dc92fb64ceaa4d7daa42345f091157bd373", size = 1690265, upload-time = "2026-08-18T21:17:51.351Z" },
 ]
 
 [[package]]
@@ -2520,11 +2519,11 @@ wheels = [
 
 [[package]]
 name = "pygments"
-version = "2.20.0"
+version = "2.21.0"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/c3/b2/bc9c9196916376152d655522fdcebac55e66de6603a76a02bca1b6414f6c/pygments-2.20.0.tar.gz", hash = "sha256:6757cd03768053ff99f3039c1a36d6c0aa0b263438fcab17520b30a303a82b5f", size = 4955991, upload-time = "2026-03-29T13:29:33.898Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/49/2e/ced460408999b33da6b31b0021b0f37d329e202d4169aeb164493778f25b/pygments-2.21.0.tar.gz", hash = "sha256:610ca751c9bc2492b38eb9a38a7fbc93edbbb2d7182edaf34e66ae493dee5c8c", size = 5005329, upload-time = "2026-08-17T08:02:48.824Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/f4/7e/a72dd26f3b0f4f2bf1dd8923c85f7ceb43172af56d63c7383eb62b332364/pygments-2.20.0-py3-none-any.whl", hash = "sha256:81a9e26dd42fd28a23a2d169d86d7ac03b46e2f8b59ed4698fb4785f946d0176", size = 1231151, upload-time = "2026-03-29T13:29:30.038Z" },
+    { url = "https://files.pythonhosted.org/packages/71/46/17f022dd3e953bf20a04a028a21ec746d942f8d2af30fa0f124fa0e6a684/pygments-2.21.0-py3-none-any.whl", hash = "sha256:2363c69b61c4a97c838da3b130dcd6468f4848992b21a82f2a63ec34377137d9", size = 1250147, upload-time = "2026-08-17T08:02:44.912Z" },
 ]
 
 [[package]]
@@ -2628,11 +2627,11 @@ wheels = [
 
 [[package]]
 name = "python-dotenv"
-version = "1.2.2"
+version = "1.2.3"
 source = { registry = "https://pypi.org/simple" }
-sdist = { url = "https://files.pythonhosted.org/packages/82/ed/0301aeeac3e5353ef3d94b6ec08bbcabd04a72018415dcb29e588514bba8/python_dotenv-1.2.2.tar.gz", hash = "sha256:2c371a91fbd7ba082c2c1dc1f8bf89ca22564a087c2c287cd9b662adde799cf3", size = 50135, upload-time = "2026-03-01T16:00:26.196Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/6a/53/ed9d74092561d4b01a2ef1349d52cdbc135e526c245f366b089cfca6de49/python_dotenv-1.2.3.tar.gz", hash = "sha256:a20a594dabeaa385725aa239d5244871c143ecb356add8a20fcf23773a6c3a35", size = 58945, upload-time = "2026-08-16T16:54:54.067Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/0b/d7/1959b9648791274998a9c3526f6d0ec8fd2233e4d4acce81bbae76b44b2a/python_dotenv-1.2.2-py3-none-any.whl", hash = "sha256:1d8214789a24de455a8b8bd8ae6fe3c6b69a5e3d64aa8a8e5d68e694bbcb285a", size = 22101, upload-time = "2026-03-01T16:00:25.09Z" },
+    { url = "https://files.pythonhosted.org/packages/0d/17/c5c6b53ddc18f297992099b3d9ec16c855c0ccc83263a21fe4d1c625ec6c/python_dotenv-1.2.3-py3-none-any.whl", hash = "sha256:904552145e8bfed22162c09dab1c2b9b54fefa7b23ba780f4f26ca0316b0f0d9", size = 22780, upload-time = "2026-08-16T16:54:52.473Z" },
 ]
 
 [[package]]
@@ -3171,18 +3170,6 @@ wheels = [
 ]
 
 [[package]]
-name = "tqdm"
-version = "4.70.0"
-source = { registry = "https://pypi.org/simple" }
-dependencies = [
-    { name = "colorama", marker = "sys_platform == 'win32'" },
-]
-sdist = { url = "https://files.pythonhosted.org/packages/21/3b/6c24bec5be5e743ffd99576daa5cc077722fc7d5bbc00bd133fa0c698dc6/tqdm-4.70.0.tar.gz", hash = "sha256:55b0b0dbd97462d06ebee91e4dac24ed4d4702be82b24f07e6c1d27e08cea220", size = 795438, upload-time = "2026-07-27T11:33:15.271Z" }
-wheels = [
-    { url = "https://files.pythonhosted.org/packages/f9/1c/01bfd571a64e7f270e6bab5e33777debe0edc56759233ce84f27dec92d14/tqdm-4.70.0-py3-none-any.whl", hash = "sha256:7f585706bfddbdebf89daac705b2dfcc16890130727d3197ca62c732b4310953", size = 80184, upload-time = "2026-07-27T11:33:13.167Z" },
-]
-
-[[package]]
 name = "truststore"
 version = "0.10.4"
 source = { registry = "https://pypi.org/simple" }
@@ -3276,16 +3263,16 @@ wheels = [
 
 [[package]]
 name = "uvicorn"
-version = "0.52.3"
+version = "0.52.4"
 source = { registry = "https://pypi.org/simple" }
 dependencies = [
     { name = "click" },
     { name = "h11" },
     { name = "typing-extensions", marker = "python_full_version < '3.11'" },
 ]
-sdist = { url = "https://files.pythonhosted.org/packages/2e/28/64ca011edf31c715b4fad359c587ea52391aaffa125065695590241ff617/uvicorn-0.52.3.tar.gz", hash = "sha256:18857b9e6579300be55c91c0a1cfd37d9a2cf0cabea33b88275f199eb73b8b58", size = 100621, upload-time = "2026-08-13T16:50:02.899Z" }
+sdist = { url = "https://files.pythonhosted.org/packages/f2/0f/3f86e61397dd33bf2ccf28188c40db6a740658aeebbbf6e7dbc101a1f487/uvicorn-0.52.4.tar.gz", hash = "sha256:73acfee47a0b133c5de13d219492d62d8a31e935f4fe6e41a232451a15379f86", size = 100627, upload-time = "2026-08-19T06:27:41.821Z" }
 wheels = [
-    { url = "https://files.pythonhosted.org/packages/dc/2b/ebd108734a8204c6b4b93c681c9a38c5273b3ccd5d129fee4ffc1d97772c/uvicorn-0.52.3-py3-none-any.whl", hash = "sha256:116af2710dbf47c80f463cd20ee4884b6662f4c9f227d797ddc7279d2fcc2c7c", size = 79859, upload-time = "2026-08-13T16:50:01.323Z" },
+    { url = "https://files.pythonhosted.org/packages/f1/79/4a20b54ab0491485ccd8c077db2d39187c7f12b3e15485d38a7be37c81b4/uvicorn-0.52.4-py3-none-any.whl", hash = "sha256:f86e41a149d7d05a9969337e3946a9c171c06a5d42680896daaba624aeac8da1", size = 79871, upload-time = "2026-08-19T06:27:40.36Z" },
 ]
 
 [package.optional-dependencies]


### PR DESCRIPTION
## Summary by Sourcery

Decouple chat preset management from global singleton state and resolve presets through the configured backend and local managers.

Bug Fixes:
- Ensure chat preset resolution and fallback switching use the current configuration rather than global singleton state.
- Prevent model selection state from being overwritten through the global preset manager.

Enhancements:
- Decouple chat preset loading, message multimodal detection, model testing, and fallback handling from the global PresetManager by using scoped preset managers and configuration-backed lookups.
- Load the configured default preset through the chat ability backend during state construction so preset handling is explicit and isolated.

Build:
- Bump the project version to 1.6.5.