### PR TITLE
Add configurable faskill skills and modernize model presets

### DIFF
--- a/amrita/plugins/chat/backends.py
+++ b/amrita/plugins/chat/backends.py
@@ -62,6 +62,17 @@ class NoopAbilityBackend(AbilityBackend):
         from .config import config_manager
 
         manager = MultiPresetManager()
-        # 配置选中的预设即默认预设；set_default_preset 会自动登记进管理器
-        manager.set_default_preset(config_manager.config.default_preset)
+        # 磁盘预设即唯一来源（default 与普通预设无差别）；重名预设跳过
+        registered: set[str] = set()
+        for preset in await config_manager.get_all_presets(cache=True):
+            if preset.name in registered:
+                continue
+            manager.add_preset(preset)
+            registered.add(preset.name)
+        # 默认预设：配置选中的预设（fix 回退保证存在）
+        default = await config_manager.get_preset(
+            config_manager.config.preset, fix=True, cache=True
+        )
+        if default is not None:
+            manager.set_default_preset(default)
         return manager

--- a/amrita/plugins/chat/backends.py
+++ b/amrita/plugins/chat/backends.py
@@ -40,8 +40,13 @@ class NoopAbilityBackend(AbilityBackend):
     其中 ``load_presets`` 构建并返回一个以配置选中预设为默认预设的
     ``MultiPresetManager``，由 Core 在 ``LOAD_STATE`` 节点抓取，从而
     彻底脱离全局单例 ``PresetManager``（其默认预设受热重载 / 脏状态影响，
-    且 Core 已改为 FailFast）。其余能力（MCP / tools / ability）由
-    ``DatabackendOptions`` 决定是否抓取。
+    且 Core 已改为 FailFast）。
+
+    ``load_tools`` 构建 faskill Skills 工具池：以全局 ``ToolsManager``
+    单例为基底克隆注册表（copy+mixin），再把已发现技能混合进克隆返回——
+    工具池包含全局工具池全部工具，同时不污染全局单例，由 Core 在
+    ``LOAD_STATE`` 节点抓取后注入 ``AbilityContext.tools``。其余能力
+    （MCP / ability）由 ``DatabackendOptions`` 决定是否抓取。
     """
 
     async def load_ability_all(self, session_id: str) -> AbilityContext:
@@ -54,7 +59,10 @@ class NoopAbilityBackend(AbilityBackend):
 
     async def load_tools(self, session_id: str) -> MultiToolsManager:
         del session_id
-        return MultiToolsManager()
+        # 延迟导入避免与 config / skills 模块产生循环依赖
+        from .skills import build_skill_tools
+
+        return build_skill_tools()
 
     async def load_presets(self, session_id: str) -> MultiPresetManager:
         del session_id

--- a/amrita/plugins/chat/backends.py
+++ b/amrita/plugins/chat/backends.py
@@ -62,7 +62,7 @@ class NoopAbilityBackend(AbilityBackend):
         # 延迟导入避免与 config / skills 模块产生循环依赖
         from .skills import build_skill_tools
 
-        return build_skill_tools()
+        return await build_skill_tools()
 
     async def load_presets(self, session_id: str) -> MultiPresetManager:
         del session_id

--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -263,9 +263,6 @@ class Config(BaseModel):
     preset_extension: PresetSwitch = Field(
         default=PresetSwitch(), description="预设模型扩展配置"
     )
-    default_preset: ModelPreset = Field(
-        default=ModelPreset(), description="默认预设配置"
-    )
     session: SessionConfig = Field(default=SessionConfig(), description="会话管理配置")
     meta: MetaInfoConfig = Field(
         default=MetaInfoConfig(), description="元信息消息显示开关"
@@ -312,6 +309,21 @@ class Config(BaseModel):
         """
         if not isinstance(data, dict):
             return data
+
+        # 迁移内嵌 default_preset → models/default.json（若目标不存在），
+        # 随后移除该键：default 预设一律由磁盘承载，配置不再内嵌模型预设。
+        if isinstance(data.get("default_preset"), dict):
+            try:
+                default_json = CONFIG_DIR / "models" / "default.json"
+                if not default_json.exists():
+                    default_json.parent.mkdir(parents=True, exist_ok=True)
+                    ModelPreset.model_validate(data["default_preset"]).save(
+                        default_json
+                    )
+            except Exception as e:
+                logger.warning(f"迁移内嵌 default_preset 失败: {e!s}")
+            data.pop("default_preset")
+
         if "core" in data:
             return data  # 已迁移
 
@@ -437,7 +449,6 @@ class ConfigManager(EnvfulConfigManager[Config]):
         # 服务构造只依赖惰性回调，配置加载前后均可安全初始化。
         self.presets = PresetService(
             self.preset_store,
-            get_config=lambda: self.config,
             get_ins_config=lambda: self.ins_config,
             save_config=lambda: self.save_config(),
         )
@@ -447,7 +458,6 @@ class ConfigManager(EnvfulConfigManager[Config]):
         )
         self.models = ModelConfigService(
             self.preset_store,
-            get_ins_config=lambda: self.ins_config,
         )
 
     @override
@@ -539,16 +549,16 @@ class ConfigManager(EnvfulConfigManager[Config]):
 
     async def get_preset(
         self, preset: str, fix: bool = False, cache: bool = True
-    ) -> ModelPreset:
+    ) -> ModelPreset | None:
         """获取预设配置（委托 PresetService，默认走缓存）
 
         Args:
             preset (str): _预设的字符串名称_
-            fix (bool, optional): _是否修正不存在的预设_. Defaults to False.
+            fix (bool, optional): _找不到时是否回退并持久化_. Defaults to False.
             cache (bool, optional): _是否使用缓存_. Defaults to True.
 
         Returns:
-            ModelPreset: _模型预设对象_
+            ModelPreset | None: _模型预设对象；找不到且未 fix 时为 None_
         """
         return await self.presets.get_preset(preset, fix=fix, cache=cache)
 

--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -86,6 +86,21 @@ class MetaInfoConfig(BaseModel):
     stream_reasoning: bool = Field(
         default=False, description="流式思考块（单token粒度，默认关闭避免刷屏）"
     )
+    skill_trigger: bool = Field(
+        default=True, description="技能触发通知（使用了xxx技能）"
+    )
+
+
+class SkillConfig(BaseModel):
+    """技能系统配置（faskill Skills）"""
+
+    enable: bool = Field(default=True, description="是否启用技能系统")
+    enabled: list[str] = Field(
+        default=[], description="显式启用白名单（空列表=全部启用）"
+    )
+    disabled: list[str] = Field(
+        default=[], description="禁用的技能名称列表（优先级高于白名单）"
+    )
 
 
 class SessionConfig(BaseModel):
@@ -264,6 +279,7 @@ class Config(BaseModel):
         default=PresetSwitch(), description="预设模型扩展配置"
     )
     session: SessionConfig = Field(default=SessionConfig(), description="会话管理配置")
+    skills: SkillConfig = Field(default=SkillConfig(), description="技能系统配置")
     meta: MetaInfoConfig = Field(
         default=MetaInfoConfig(), description="元信息消息显示开关"
     )

--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -97,9 +97,7 @@ class SkillConfig(BaseModel):
     enable: bool = Field(default=True, description="是否启用技能系统")
     selected: list[str] = Field(
         default=[],
-        description=(
-            "启用的技能名称列表（空列表=全部启用；非空则仅列表内的技能启用）"
-        ),
+        description=("启用的技能名称列表（空列表=全部启用；非空则仅列表内的技能启用）"),
     )
 
 

--- a/amrita/plugins/chat/config.py
+++ b/amrita/plugins/chat/config.py
@@ -95,11 +95,11 @@ class SkillConfig(BaseModel):
     """技能系统配置（faskill Skills）"""
 
     enable: bool = Field(default=True, description="是否启用技能系统")
-    enabled: list[str] = Field(
-        default=[], description="显式启用白名单（空列表=全部启用）"
-    )
-    disabled: list[str] = Field(
-        default=[], description="禁用的技能名称列表（优先级高于白名单）"
+    selected: list[str] = Field(
+        default=[],
+        description=(
+            "启用的技能名称列表（空列表=全部启用；非空则仅列表内的技能启用）"
+        ),
     )
 
 
@@ -498,6 +498,22 @@ class ConfigManager(EnvfulConfigManager[Config]):
             await self.get_all_presets(False)
             logger.success("完成")
 
+        async def skills_callback():
+            # 延迟导入避免循环依赖（skills.py 顶层 import 本模块）
+            from .skills import reload_skills
+
+            logger.info("正在重载技能目录...")
+            results = await reload_skills()
+            failed = [r.name for r in results if not r.ok]
+            if failed:
+                logger.warning(
+                    "技能目录变化，重新加载后 %d 个技能校验失败: %s",
+                    len(failed),
+                    failed,
+                )
+            else:
+                logger.success(f"技能目录已重载: {len(results)} 个技能")
+
         logger.info("正在初始化存储目录...")
         logger.debug(f"配置目录: {self.config_dir}")
         os.makedirs(self.config_dir, exist_ok=True)
@@ -508,6 +524,16 @@ class ConfigManager(EnvfulConfigManager[Config]):
         await UniConfigManager().add_directory(
             "models",
             lambda *_: models_callback(),
+            owner_name="chat",
+        )
+        # 技能目录回调：目录内文件变化自动重新 discover（复用 uniconf 监听）。
+        # 注意：自定义 filter 会替换默认过滤（final_filter = filter or default_filter），
+        # 故需自行检查路径前缀。不限后缀：技能目录除 SKILL.md 外还可能含脚本
+        # （.py/.sh 等，渐进披露 L3 的 skill.scripts），任何文件变化都应触发重载。
+        await UniConfigManager().add_directory(
+            "skills",
+            lambda *_: skills_callback(),
+            lambda change: change[1].startswith(str(self.config_dir / "skills")),
             owner_name="chat",
         )
         self.validate_presets()

--- a/amrita/plugins/chat/handlers/chat/__init__.py
+++ b/amrita/plugins/chat/handlers/chat/__init__.py
@@ -146,7 +146,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
     strategy = select_agent_strategy(config.llm.agent_strategy)
 
     # 构建定制化的 system prompt（与 /compact、/session info 共用同一构建逻辑）
-    train_dict = build_train_dict(event, memory, config)
+    train_dict = await build_train_dict(event, memory, config)
 
     #  阶段 4：创建 ChatObject
     ctx: AmritaBotContext = {

--- a/amrita/plugins/chat/handlers/chat/__init__.py
+++ b/amrita/plugins/chat/handlers/chat/__init__.py
@@ -172,7 +172,9 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
         ),
         backend_options=DatabackendOptions(
             skip_mcp_fetch=True,
-            skip_tools_fetch=True,
+            # skip_tools_fetch 保持默认 False：由数据后端 load_tools 注入
+            # faskill Skills 工具池（独立 MultiToolsManager，非全局单例）
+            skip_tools_fetch=False,
         ),
     )
 
@@ -192,9 +194,7 @@ async def entry(event: MessageEvent, matcher: Matcher, bot: Bot):
 
     # 按 chat_pending_mode 处理锁占用场景（single / single_with_report /
     # interactive / queue）。返回 True 表示已停止本次流程。
-    if await get_pending_mode_strategy(
-        config.function.chat_pending_mode
-    ).handle_locked(
+    if await get_pending_mode_strategy(config.function.chat_pending_mode).handle_locked(
         lock=lock,
         matcher=matcher,
         event=event,

--- a/amrita/plugins/chat/handlers/chat/usage.py
+++ b/amrita/plugins/chat/handlers/chat/usage.py
@@ -32,15 +32,11 @@ async def _estimate_usage(chat: CoreChatObject) -> UniResponseUsage:
     assert response is not None
     resp: str = response.content
     usg_prompt: int = 0
-    for i in text_generator(
-        chat._di_working.context_wrap.unwrap(), full_message=True
-    ):
+    for i in text_generator(chat._di_working.context_wrap.unwrap(), full_message=True):
         usg_prompt += await asyncio.to_thread(
             hybrid_token_count, i, tokenizer_type="jieba"
         )
-    usg_gen = await asyncio.to_thread(
-        hybrid_token_count, resp, tokenizer_type="jieba"
-    )
+    usg_gen = await asyncio.to_thread(hybrid_token_count, resp, tokenizer_type="jieba")
     return UniResponseUsage(
         prompt_tokens=usg_prompt,
         completion_tokens=usg_gen,

--- a/amrita/plugins/chat/handlers/insights.py
+++ b/amrita/plugins/chat/handlers/insights.py
@@ -24,9 +24,7 @@ _TOP_MAX = 50  # 排名数量上限，防止刷屏
 
 def _format_user_entry(i: int, user: UserMetadata, label: str) -> str:
     """格式化排名条目"""
-    user_id = (
-        user.user_id.split("_", 1)[1] if "_" in user.user_id else user.user_id
-    )
+    user_id = user.user_id.split("_", 1)[1] if "_" in user.user_id else user.user_id
     total_tokens = user.tokens_input + user.tokens_output
     return f"{i}. {label}{user_id}: {user.called_count}次, {total_tokens}tokens\n"
 

--- a/amrita/plugins/chat/handlers/model.py
+++ b/amrita/plugins/chat/handlers/model.py
@@ -49,7 +49,10 @@ async def model_switch(
 
 async def model_info(event: MessageEvent, matcher: Matcher, bot: Bot) -> None:
     """展示当前模型的详细信息（模型名、思考深度）"""
-    preset = await config_manager.get_preset(config_manager.config.preset)
+    preset = await config_manager.get_preset(
+        config_manager.config.preset, fix=True, cache=True
+    )
+    assert preset is not None  # fix 回退保证存在（目录为空时默认创建 default）
     msg = (
         f"当前模型：{preset.name}（{preset.model}）\n"
         f"接口：{preset.base_url or '默认'}\n"
@@ -68,12 +71,12 @@ async def model_test(
     """测试指定模型（不指定则测试全部）"""
     pm = MultiPresetManager()
     if name:
-        try:
-            presets = [await config_manager.get_preset(name)]
-        except Exception:
+        preset = await config_manager.get_preset(name, fix=False, cache=True)
+        if preset is None:
             await matcher.finish(
                 f"未找到模型 {name}，请输入 /model list 查看可用模型。"
             )
+        presets = [preset]
     else:
         presets = await config_manager.get_all_presets(True)
     if TEST_LOCK.locked():

--- a/amrita/plugins/chat/handlers/session_cmd.py
+++ b/amrita/plugins/chat/handlers/session_cmd.py
@@ -150,7 +150,7 @@ async def _session_info(event: MessageEvent, matcher: Matcher) -> None:
     data = memory.memory_json
 
     preset = await resolve_preset()
-    train = build_train_dict(event, memory, config)
+    train = await build_train_dict(event, memory, config)
     max_tokens = config.core.llm.session_tokens_windows
     total = await asyncio.to_thread(estimate_tokens, train, memory, config)
 
@@ -185,7 +185,7 @@ async def _session_compact(event: MessageEvent, matcher: Matcher, force: bool) -
     if not data.messages:
         await matcher.finish("当前会话为空，无需压缩。")
 
-    train = build_train_dict(event, memory, config)
+    train = await build_train_dict(event, memory, config)
     max_tokens = config.core.llm.session_tokens_windows
     current_tokens = await asyncio.to_thread(estimate_tokens, train, memory, config)
 

--- a/amrita/plugins/chat/handlers/session_cmd.py
+++ b/amrita/plugins/chat/handlers/session_cmd.py
@@ -209,7 +209,12 @@ async def _session_compact(event: MessageEvent, matcher: Matcher, force: bool) -
 
     try:
         async with repo.make_lock(uni_id):
-            async with MemoryLimiter(data, train, config=work_config,preset=await resolve_preset(config.preset)) as lim:
+            async with MemoryLimiter(
+                data,
+                train,
+                config=work_config,
+                preset=await resolve_preset(config.preset),
+            ) as lim:
                 await lim.run_enforce()
                 usage = lim.usage
     except Exception as e:

--- a/amrita/plugins/chat/preprocess/startup.py
+++ b/amrita/plugins/chat/preprocess/startup.py
@@ -1,5 +1,6 @@
 from nonebot import get_driver, logger
 
+from ..skills import validate_skills
 from .deps import setup_core_runtime
 
 driver = get_driver()
@@ -9,4 +10,11 @@ driver = get_driver()
 async def onEnable():
     logger.debug("加载配置文件...")
     await setup_core_runtime()
+    # 尽力加载并校验 skills 目录（单个技能失败仅记录日志，不阻断启动）
+    results = validate_skills()
+    failed = [r.name for r in results if not r.ok]
+    if failed:
+        logger.warning(f"技能加载校验失败 {len(failed)} 个: {failed}")
+    elif results:
+        logger.info(f"技能加载校验完成: {len(results)} 个技能")
     logger.debug("成功启动！")

--- a/amrita/plugins/chat/preprocess/startup.py
+++ b/amrita/plugins/chat/preprocess/startup.py
@@ -10,8 +10,9 @@ driver = get_driver()
 async def onEnable():
     logger.debug("加载配置文件...")
     await setup_core_runtime()
-    # 尽力加载并校验 skills 目录（单个技能失败仅记录日志，不阻断启动）
-    results = validate_skills()
+    # 尽力加载并校验 skills 目录（单个技能失败仅记录日志，不阻断启动）；
+    # 目录监听由 config 的 skills 目录回调负责（add_directory），无需自建任务
+    results = await validate_skills()
     failed = [r.name for r in results if not r.ok]
     if failed:
         logger.warning(f"技能加载校验失败 {len(failed)} 个: {failed}")

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -39,8 +39,10 @@ class PresetStore:
                 logger.opt(colors=True, raw=True).error(
                     f"Failed to validate preset '{path!s}' because '{e!s}'"
                 )
-        # 默认创建：预设目录为空时创建一个 default 预设（初始状态）
-        if not self._loaded:
+        # 默认创建：目录为空（或全部文件校验失败）时创建一个 default 预设
+        # （初始状态）。以 _by_name 判断而非 _loaded：validate 只登记
+        # _by_name，_loaded 是 load_all 的缓存（含 env 替换），两者语义不同
+        if not self._by_name:
             self.ensure_default_sync()
 
     async def load_all(self, *, cache: bool = False) -> list[ModelPreset]:

--- a/amrita/plugins/chat/preset_store.py
+++ b/amrita/plugins/chat/preset_store.py
@@ -39,6 +39,9 @@ class PresetStore:
                 logger.opt(colors=True, raw=True).error(
                     f"Failed to validate preset '{path!s}' because '{e!s}'"
                 )
+        # 默认创建：预设目录为空时创建一个 default 预设（初始状态）
+        if not self._loaded:
+            self.ensure_default_sync()
 
     async def load_all(self, *, cache: bool = False) -> list[ModelPreset]:
         """加载全部预设（不依赖全局 PresetManager 单例）"""
@@ -56,7 +59,34 @@ class PresetStore:
             self._by_name[model_preset.name] = lp
             self._loaded.append(lp)
 
+        # 默认创建：预设目录为空时创建一个 default 预设（初始状态）。
+        # default 与其他预设无差别：可编辑、可删除，删除后不会自动复活。
+        if not self._loaded:
+            self.ensure_default_sync()
+
         return [lp.preset for lp in self._loaded]
+
+    def ensure_default_sync(self) -> ModelPreset:
+        """默认创建：确保存在名为 ``default`` 的预设；缺失时以 ``default.json`` 落地并登记。
+
+        default 是普通预设，不做任何特殊处理；``default.json`` 已存在时直接
+        加载（内容以文件为准）。供初始化/空目录场景调用。
+        """
+        existing = next(
+            (lp for lp in self._loaded if lp.preset.name == "default"), None
+        )
+        if existing is not None:
+            return existing.preset
+        path = self.models_dir / "default.json"
+        if path.exists():
+            preset = ModelPreset.load(path)
+        else:
+            preset = ModelPreset(name="default")
+            preset.save(path)
+        lp = LoadedPreset(preset, path.stem, path)
+        self._by_name["default"] = lp
+        self._loaded.append(lp)
+        return preset
 
     async def find(self, name: str, *, cache: bool = False) -> ModelPreset | None:
         """按名查找预设"""
@@ -69,8 +99,9 @@ class PresetStore:
         return self._by_name[name].path
 
     def forget(self, name: str) -> None:
-        """移除预设名到路径的记录"""
+        """移除预设名到路径的记录（缓存中的 _loaded 一并清理，保持一致性）"""
         self._by_name.pop(name, None)
+        self._loaded = [lp for lp in self._loaded if lp.preset.name != name]
 
     def register_extra(self, key: str, default_value: Any) -> None:
         """给所有预设补默认 extra 字段并存盘"""

--- a/amrita/plugins/chat/services/model.py
+++ b/amrita/plugins/chat/services/model.py
@@ -6,13 +6,9 @@
 
 from __future__ import annotations
 
-from collections.abc import Callable
-from typing import TYPE_CHECKING, Any
+from typing import Any
 
 from ..preset_store import PresetStore
-
-if TYPE_CHECKING:
-    from ..config import Config
 
 
 class ModelConfigService:
@@ -21,13 +17,11 @@ class ModelConfigService:
     def __init__(
         self,
         preset_store: PresetStore,
-        get_ins_config: Callable[[], Config],
     ) -> None:
         self._preset_store = preset_store
-        self._get_ins_config = get_ins_config
 
     def reg_model_config(self, key: str, default_value: Any = None) -> None:
-        """注册模型配置项：写入默认预设 extra，并为全部已加载预设补默认值。
+        """注册模型配置项：写入 default 预设的 extra，并为全部已加载预设补默认值。
 
         Args:
             key: 配置项名称
@@ -35,7 +29,7 @@ class ModelConfigService:
         """
         if default_value is None:
             default_value = "null"
-        ins = self._get_ins_config()
-        if key not in ins.default_preset.extra:
-            ins.default_preset.extra.setdefault(key, default_value)
+        # default 预设以磁盘 default.json 承载（配置不再内嵌），
+        # 先同步兜底确保其存在，再给所有已加载预设补默认值并存盘
+        self._preset_store.ensure_default_sync()
         self._preset_store.register_extra(key, default_value)

--- a/amrita/plugins/chat/services/preset.py
+++ b/amrita/plugins/chat/services/preset.py
@@ -25,19 +25,12 @@ class PresetService:
     def __init__(
         self,
         store: PresetStore,
-        get_config: Callable[[], Config],
         get_ins_config: Callable[[], Config],
         save_config: Callable[[], Awaitable[None]],
     ) -> None:
         self._store = store
-        self._get_config = get_config
         self._get_ins_config = get_ins_config
         self._save_config = save_config
-
-    @property
-    def _config(self) -> Config:
-        """env 替换后的配置副本（读 default_preset 用）"""
-        return self._get_config()
 
     @property
     def _ins_config(self) -> Config:
@@ -51,36 +44,41 @@ class PresetService:
     async def get_all_presets(self, *, cache: bool = True) -> list[ModelPreset]:
         """获取全部预设（默认走缓存）。
 
+        预设全部来自磁盘目录（``models/*.json``）；``default`` 与普通预设
+        无差别，仅当目录为空时由 ``PresetStore`` 默认创建一个。
+
         Args:
             cache: 是否使用磁盘预设缓存；热重载时显式传 ``False`` 强制刷新
         """
-        return [
-            self._config.default_preset,
-            *(await self._store.load_all(cache=cache)),
-        ]
+        return await self._store.load_all(cache=cache)
 
     async def get_preset(
         self, preset: str, fix: bool = False, *, cache: bool = True
-    ) -> ModelPreset:
+    ) -> ModelPreset | None:
         """解析预设名 → ``ModelPreset``。
 
-        - ``"default"`` 直接返回配置默认预设（env 已替换）
-        - 磁盘预设按名查找（默认缓存）
-        - ``fix=True`` 且找不到时回退 ``default`` 并持久化写回
+        - 磁盘预设按名查找（默认缓存），default 无任何特殊处理
+        - ``fix=True`` 且找不到时回退到 ``default``（亦不存在则回退到
+          第一个可用预设），并持久化写回选中预设；预设目录为空时
+          ``load_all`` 会默认创建 ``default``，因此回退始终有结果
 
         Args:
             preset: 预设名称
-            fix: 找不到时是否修正为 ``default`` 并保存配置
+            fix: 找不到时是否回退并保存配置
             cache: 是否使用磁盘预设缓存（默认 True）
         """
-        if preset == "default":
-            return self._config.default_preset
         if (model := await self._store.find(preset, cache=cache)) is not None:
             return model
         if fix:
-            self._ins_config.preset = "default"
-            await self._save_config()
-        return await self.get_preset("default", fix, cache=cache)
+            fallback = await self._store.find("default", cache=cache)
+            if fallback is None:
+                presets = await self._store.load_all(cache=cache)
+                fallback = presets[0] if presets else None
+            if fallback is not None:
+                self._ins_config.preset = fallback.name
+                await self._save_config()
+                return fallback
+        return None
 
     def get_preset_path(self, name: str) -> Path:
         """预设名对应的文件路径"""

--- a/amrita/plugins/chat/skills.py
+++ b/amrita/plugins/chat/skills.py
@@ -89,9 +89,7 @@ async def get_skill_context() -> SkillContext:
         async with _skill_init_lock:
             if _skill_context is None:
                 SKILLS_DIR.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
-                ctx = await asyncio.to_thread(
-                    create_context, skill_dirs=[SKILLS_DIR]
-                )
+                ctx = await asyncio.to_thread(create_context, skill_dirs=[SKILLS_DIR])
                 await asyncio.to_thread(ctx.discover)
                 _skill_context = ctx
     return _skill_context

--- a/amrita/plugins/chat/skills.py
+++ b/amrita/plugins/chat/skills.py
@@ -1,0 +1,282 @@
+"""faskill Skills 集成服务。
+
+技能目录与 model preset 目录（``config/chat/models/``）同级，即
+``config/chat/skills/``；每个技能以标准 ``SKILL.md`` 格式描述，由 faskill
+发现、加载与调用（Anthropic Agent Skills 兼容）。
+
+工具池注入方式（关键约束）：
+
+- ``load_tools`` 通过数据后端（``NoopAbilityBackend``）构建会话级工具池：
+  以全局 ``ToolsManager`` 单例为基底**克隆**（copy+mixin），再把技能工具
+  混合进克隆返回——既保留全局工具池全部工具，又不污染全局单例；
+- 技能工具的 handler 采用 ``custom_run=True`` 自定义执行：调用技能前通过
+  ``io_stream`` 推送 ``type="skill_call"`` 元信息消息，由 chat 的 sender
+  按 ``[meta]`` 配置决定是否发送"使用了xxx技能"的通知；
+- 启停过滤：``[skills]`` 配置（enable/enabled/disabled）决定哪些技能被注册
+  进工具池、写入 system prompt 使用指引；
+- 加载校验：``validate_skills`` 在插件启动时尽力解析/加载全部技能并返回
+  状态列表（单个技能失败仅记录日志，不阻断启动），供 WebUI 展示。
+"""
+
+from __future__ import annotations
+
+import asyncio
+from dataclasses import dataclass
+from pathlib import Path
+
+from amrita_core.contents import MessageMetadataPayload, MessageWithMetadata
+from amrita_core.tools.manager import MultiToolsManager, ToolsManager
+from amrita_core.tools.models import (
+    FunctionDefinitionSchema,
+    FunctionParametersSchema,
+    FunctionPropertySchema,
+    ToolContext,
+    ToolData,
+    ToolFunctionSchema,
+)
+from faskill import SkillContext, create_context
+from faskill.integrations.amcore import (
+    clone_tools_manager,
+    register_amrita_script_tools,
+)
+from nonebot import logger
+
+from .config import CONFIG_DIR, config_manager
+
+# 技能目录：与 model preset 目录（config/chat/models/）同级
+SKILLS_DIR: Path = CONFIG_DIR / "skills"
+
+# 技能工具的唯一参数名：用户请求原文透传（经 $ARGUMENTS 注入模板）
+_ARGUMENTS_PARAM = "arguments"
+
+_skill_context: SkillContext | None = None
+
+
+class SkillCallMetadata(MessageMetadataPayload):
+    """技能触发元信息载荷（type=skill_call）"""
+
+    skill_name: str
+
+
+@dataclass
+class SkillValidationResult:
+    """单个技能的加载校验结果"""
+
+    name: str
+    description: str
+    version: str | None
+    path: str
+    enabled: bool
+    ok: bool
+    error: str | None
+
+
+def get_skill_context() -> SkillContext:
+    """返回模块级缓存的 ``SkillContext``（首次调用时 discover）。
+
+    技能目录不存在时自动创建（faskill 要求目录存在）；目录为空时
+    技能列表为空，``build_skill_usage_prompt`` 返回空字符串。
+    """
+    global _skill_context
+    if _skill_context is None:
+        SKILLS_DIR.mkdir(parents=True, exist_ok=True)
+        ctx = create_context(skill_dirs=[SKILLS_DIR])
+        ctx.discover()
+        _skill_context = ctx
+    return _skill_context
+
+
+def _skill_enabled(name: str) -> bool:
+    """按 ``[skills]`` 配置判断技能是否启用。
+
+    配置未就绪（插件启动早期）时视为启用；黑名单优先级高于白名单。
+    """
+    cfg = getattr(config_manager, "ins_config", None)
+    skills_cfg = getattr(cfg, "skills", None)
+    if skills_cfg is None:
+        return True
+    if not skills_cfg.enable:
+        return False
+    if name in skills_cfg.disabled:
+        return False
+    if skills_cfg.enabled and name not in skills_cfg.enabled:
+        return False
+    return True
+
+
+def _build_arguments_schema(name: str, description: str) -> ToolFunctionSchema:
+    """构建单参数（arguments 字符串）技能工具 schema（与 faskill 一致）。"""
+    return ToolFunctionSchema(
+        type="function",
+        strict=True,
+        function=FunctionDefinitionSchema(
+            name=name,
+            description=description,
+            parameters=FunctionParametersSchema(
+                type="object",
+                properties={
+                    _ARGUMENTS_PARAM: FunctionPropertySchema(
+                        type="string",
+                        description=(
+                            "Arguments to pass to the skill (empty string if none)"
+                        ),
+                    ),
+                },
+                required=[_ARGUMENTS_PARAM],
+            ),
+        ),
+    )
+
+
+def _make_skill_handler(
+    ctx: SkillContext,
+    skill_name: str,
+    tools: MultiToolsManager,
+):
+    """构建 ``custom_run=True`` 技能工具 handler。
+
+    职责：
+    1. 调用前通过 ``io_stream`` 推送 ``type="skill_call"`` 元信息消息
+       （sender 按 ``meta.skill_trigger`` 决定是否发送"使用了xxx技能"）；
+    2. 在工作线程执行技能（同步 API，避免阻塞事件循环）；
+    3. 渐进披露 L3：技能被调用后将其脚本工具注册进同一会话工具池。
+    """
+
+    async def invoke_skill(tc: ToolContext) -> str:
+        arguments = tc.data.get(_ARGUMENTS_PARAM, "")
+        if arguments is None:
+            arguments = ""
+
+        # 技能触发元信息消息（chat sender 依据 [meta] 配置决定是否展示）
+        stream = tc.ctx.io_stream
+        if stream is not None:
+            try:
+                await stream.yield_response(
+                    MessageWithMetadata(
+                        content=f"使用了技能：{skill_name}",
+                        metadata=SkillCallMetadata(
+                            type="skill_call",
+                            extra_type=None,
+                            skill_name=skill_name,
+                        ),
+                    )
+                )
+            except Exception:
+                logger.opt(exception=True, colors=True, raw=True).warning(
+                    "推送技能触发元信息失败: %s", skill_name
+                )
+
+        # 执行技能（同步 API 放工作线程，避免阻塞事件循环）
+        result = await asyncio.to_thread(ctx.invoke_skill, skill_name, str(arguments))
+
+        # 渐进披露 L3：技能被调用后，其脚本工具注入同一会话工具池
+        try:
+            skill = ctx.load_skill(skill_name)
+            if skill.scripts:
+                register_amrita_script_tools(
+                    skill, ctx, tools_manager=tools, copy=False
+                )
+        except Exception:
+            logger.opt(exception=True, colors=True, raw=True).debug(
+                "技能脚本工具激活失败: %s", skill_name
+            )
+
+        return result
+
+    return invoke_skill
+
+
+def build_skill_tools() -> MultiToolsManager:
+    """构建会话级技能工具池（copy+mixin + 启停过滤 + 触发元信息推送）。
+
+    以全局 ``ToolsManager()`` 单例为基底克隆其注册表（``copy=True``），
+    再把**启用**的技能工具（``custom_run=True`` handler）混合进克隆返回：
+    返回的工具池包含全局工具池的全部工具，且注册技能不会改写全局单例。
+
+    progressive disclosure：技能被模型调用时，其脚本工具才注入同一管理器。
+    由数据后端 ``load_tools`` 每次会话抓取。
+    """
+    ctx = get_skill_context()
+    # copy+mixin：克隆全局注册表，保留全部全局工具且不污染单例
+    tools = clone_tools_manager(ToolsManager())
+    for meta in ctx.list_skills(include_qualified=False):
+        if not _skill_enabled(meta.name):
+            continue
+        if tools.has_tool(meta.name):
+            continue
+        tools.register_tool(
+            ToolData(
+                data=_build_arguments_schema(meta.name, meta.description),
+                func=_make_skill_handler(ctx, meta.name, tools),
+                custom_run=True,
+            )
+        )
+    return tools
+
+
+def build_skill_usage_prompt() -> str:
+    """构建 system prompt 技能使用指引（过滤禁用技能；无可用技能返回空串）。"""
+    ctx = get_skill_context()
+    skills = [
+        meta
+        for meta in ctx.list_skills(include_qualified=False)
+        if _skill_enabled(meta.name)
+    ]
+    if not skills:
+        return ""
+    lines = [
+        "## Available faskill skills",
+        "Call a skill tool when the user's task matches its purpose:",
+    ]
+    lines.extend(f"- {meta.name}: {meta.description}" for meta in skills)
+    lines.append(
+        "Call a skill tool when the user's task matches its purpose. "
+        'Pass the user\'s request as the "arguments" string; it is inserted '
+        "into the skill template via $ARGUMENTS. "
+        "The tool returns the processed skill output (markdown)."
+    )
+    return "\n".join(lines)
+
+
+def validate_skills() -> list[SkillValidationResult]:
+    """加载并校验技能目录中的全部技能（尽力而为，不阻断启动）。
+
+    discover 已尽力解析 SKILL.md frontmatter（失败仅记录日志）；这里对
+    每个技能执行完整加载（触发正文解析），汇总状态供 WebUI 展示。
+    """
+    ctx = get_skill_context()
+    results: list[SkillValidationResult] = []
+    for meta in ctx.list_skills(include_qualified=False):
+        error: str | None = None
+        ok = True
+        try:
+            ctx.load_skill(meta.name)
+        except Exception as e:
+            ok = False
+            error = f"{type(e).__name__}: {e}"
+            logger.opt(exception=e, colors=True, raw=True).warning(
+                "技能加载校验失败: %s", meta.name
+            )
+        results.append(
+            SkillValidationResult(
+                name=meta.name,
+                description=meta.description,
+                version=meta.version,
+                path=str(meta.skill_path),
+                enabled=_skill_enabled(meta.name),
+                ok=ok,
+                error=error,
+            )
+        )
+    return results
+
+
+def reload_skills() -> list[SkillValidationResult]:
+    """重新 discover 并校验全部技能（拾取新增/修改的技能文件）。
+
+    丢弃模块级缓存的 ``SkillContext`` 并重新发现：修改 SKILL.md 后调用
+    可让新增/更新的技能立即生效（下次构建工具池时按新列表注册）。
+    """
+    global _skill_context
+    _skill_context = None
+    return validate_skills()

--- a/amrita/plugins/chat/skills.py
+++ b/amrita/plugins/chat/skills.py
@@ -12,7 +12,7 @@
 - 技能工具的 handler 采用 ``custom_run=True`` 自定义执行：调用技能前通过
   ``io_stream`` 推送 ``type="skill_call"`` 元信息消息，由 chat 的 sender
   按 ``[meta]`` 配置决定是否发送"使用了xxx技能"的通知；
-- 启停过滤：``[skills]`` 配置（enable/enabled/disabled）决定哪些技能被注册
+- 启停过滤：``[skills]`` 配置（enable/selected）决定哪些技能被注册
   进工具池、写入 system prompt 使用指引；
 - 加载校验：``validate_skills`` 在插件启动时尽力解析/加载全部技能并返回
   状态列表（单个技能失败仅记录日志，不阻断启动），供 WebUI 展示。
@@ -41,13 +41,16 @@ from faskill.integrations.amcore import (
 )
 from nonebot import logger
 
-from .config import CONFIG_DIR, config_manager
+from .config import CONFIG_DIR, SkillConfig, config_manager
 
 # 技能目录：与 model preset 目录（config/chat/models/）同级
 SKILLS_DIR: Path = CONFIG_DIR / "skills"
 
 # 技能工具的唯一参数名：用户请求原文透传（经 $ARGUMENTS 注入模板）
 _ARGUMENTS_PARAM = "arguments"
+
+# SkillContext 异步初始化互斥锁：discover/重载均在工作线程执行，锁防并发重复创建
+_skill_init_lock = asyncio.Lock()
 
 _skill_context: SkillContext | None = None
 
@@ -71,35 +74,37 @@ class SkillValidationResult:
     error: str | None
 
 
-def get_skill_context() -> SkillContext:
-    """返回模块级缓存的 ``SkillContext``（首次调用时 discover）。
+async def get_skill_context() -> SkillContext:
+    """返回模块级缓存的 ``SkillContext``（异步初始化，首次调用时 discover）。
 
     技能目录不存在时自动创建（faskill 要求目录存在）；目录为空时
     技能列表为空，``build_skill_usage_prompt`` 返回空字符串。
+
+    以异步方式初始化：faskill 的 ``create_context``/``discover`` 为同步
+    API（含磁盘扫描与 frontmatter 解析），放入工作线程执行避免阻塞事件
+    循环；``asyncio.Lock`` 保证并发首次调用只创建一次。
     """
     global _skill_context
     if _skill_context is None:
-        SKILLS_DIR.mkdir(parents=True, exist_ok=True)
-        ctx = create_context(skill_dirs=[SKILLS_DIR])
-        ctx.discover()
-        _skill_context = ctx
+        async with _skill_init_lock:
+            if _skill_context is None:
+                SKILLS_DIR.mkdir(parents=True, exist_ok=True)  # noqa: ASYNC240
+                ctx = await asyncio.to_thread(
+                    create_context, skill_dirs=[SKILLS_DIR]
+                )
+                await asyncio.to_thread(ctx.discover)
+                _skill_context = ctx
     return _skill_context
 
 
-def _skill_enabled(name: str) -> bool:
+def _skill_enabled(name: str, skills_cfg: SkillConfig) -> bool:
     """按 ``[skills]`` 配置判断技能是否启用。
 
-    配置未就绪（插件启动早期）时视为启用；黑名单优先级高于白名单。
+    ``selected`` 非空时仅列表内的技能启用（空列表 = 全部启用）。
     """
-    cfg = getattr(config_manager, "ins_config", None)
-    skills_cfg = getattr(cfg, "skills", None)
-    if skills_cfg is None:
-        return True
     if not skills_cfg.enable:
         return False
-    if name in skills_cfg.disabled:
-        return False
-    if skills_cfg.enabled and name not in skills_cfg.enabled:
+    if skills_cfg.selected and name not in skills_cfg.selected:
         return False
     return True
 
@@ -186,7 +191,7 @@ def _make_skill_handler(
     return invoke_skill
 
 
-def build_skill_tools() -> MultiToolsManager:
+async def build_skill_tools() -> MultiToolsManager:
     """构建会话级技能工具池（copy+mixin + 启停过滤 + 触发元信息推送）。
 
     以全局 ``ToolsManager()`` 单例为基底克隆其注册表（``copy=True``），
@@ -196,11 +201,12 @@ def build_skill_tools() -> MultiToolsManager:
     progressive disclosure：技能被模型调用时，其脚本工具才注入同一管理器。
     由数据后端 ``load_tools`` 每次会话抓取。
     """
-    ctx = get_skill_context()
+    ctx = await get_skill_context()
+    skills_cfg = config_manager.ins_config.skills
     # copy+mixin：克隆全局注册表，保留全部全局工具且不污染单例
     tools = clone_tools_manager(ToolsManager())
     for meta in ctx.list_skills(include_qualified=False):
-        if not _skill_enabled(meta.name):
+        if not _skill_enabled(meta.name, skills_cfg):
             continue
         if tools.has_tool(meta.name):
             continue
@@ -214,13 +220,14 @@ def build_skill_tools() -> MultiToolsManager:
     return tools
 
 
-def build_skill_usage_prompt() -> str:
+async def build_skill_usage_prompt() -> str:
     """构建 system prompt 技能使用指引（过滤禁用技能；无可用技能返回空串）。"""
-    ctx = get_skill_context()
+    ctx = await get_skill_context()
+    skills_cfg = config_manager.ins_config.skills
     skills = [
         meta
         for meta in ctx.list_skills(include_qualified=False)
-        if _skill_enabled(meta.name)
+        if _skill_enabled(meta.name, skills_cfg)
     ]
     if not skills:
         return ""
@@ -238,45 +245,53 @@ def build_skill_usage_prompt() -> str:
     return "\n".join(lines)
 
 
-def validate_skills() -> list[SkillValidationResult]:
+async def validate_skills() -> list[SkillValidationResult]:
     """加载并校验技能目录中的全部技能（尽力而为，不阻断启动）。
 
     discover 已尽力解析 SKILL.md frontmatter（失败仅记录日志）；这里对
     每个技能执行完整加载（触发正文解析），汇总状态供 WebUI 展示。
+
+    ``load_skill`` 为同步 API，整体放入工作线程执行（异步初始化）。
     """
-    ctx = get_skill_context()
-    results: list[SkillValidationResult] = []
-    for meta in ctx.list_skills(include_qualified=False):
-        error: str | None = None
-        ok = True
-        try:
-            ctx.load_skill(meta.name)
-        except Exception as e:
-            ok = False
-            error = f"{type(e).__name__}: {e}"
-            logger.opt(exception=e, colors=True, raw=True).warning(
-                "技能加载校验失败: %s", meta.name
+    ctx = await get_skill_context()
+    skills_cfg = config_manager.ins_config.skills
+
+    def _load_all() -> list[SkillValidationResult]:
+        results: list[SkillValidationResult] = []
+        for meta in ctx.list_skills(include_qualified=False):
+            error: str | None = None
+            ok = True
+            try:
+                ctx.load_skill(meta.name)
+            except Exception as e:
+                ok = False
+                error = f"{type(e).__name__}: {e}"
+                logger.opt(exception=e, colors=True, raw=True).warning(
+                    "技能加载校验失败: %s", meta.name
+                )
+            results.append(
+                SkillValidationResult(
+                    name=meta.name,
+                    description=meta.description,
+                    version=meta.version,
+                    path=str(meta.skill_path),
+                    enabled=_skill_enabled(meta.name, skills_cfg),
+                    ok=ok,
+                    error=error,
+                )
             )
-        results.append(
-            SkillValidationResult(
-                name=meta.name,
-                description=meta.description,
-                version=meta.version,
-                path=str(meta.skill_path),
-                enabled=_skill_enabled(meta.name),
-                ok=ok,
-                error=error,
-            )
-        )
-    return results
+        return results
+
+    return await asyncio.to_thread(_load_all)
 
 
-def reload_skills() -> list[SkillValidationResult]:
+async def reload_skills() -> list[SkillValidationResult]:
     """重新 discover 并校验全部技能（拾取新增/修改的技能文件）。
 
     丢弃模块级缓存的 ``SkillContext`` 并重新发现：修改 SKILL.md 后调用
     可让新增/更新的技能立即生效（下次构建工具池时按新列表注册）。
     """
     global _skill_context
-    _skill_context = None
-    return validate_skills()
+    async with _skill_init_lock:
+        _skill_context = None
+    return await validate_skills()

--- a/amrita/plugins/chat/utils/context.py
+++ b/amrita/plugins/chat/utils/context.py
@@ -51,7 +51,7 @@ def _format_desc_legacy() -> str:
     )
 
 
-def build_train_dict(
+async def build_train_dict(
     event: MessageEvent, memory: MemorySchema, config: Config
 ) -> dict[str, str]:
     """构建 system prompt（与 chat 主流程完全一致）
@@ -92,7 +92,7 @@ def build_train_dict(
             if config.function.allow_custom_prompt
             else ""
         )
-        + build_skill_usage_prompt()
+        + (await build_skill_usage_prompt())
     )
     return {"role": "system", "content": train_content}
 

--- a/amrita/plugins/chat/utils/context.py
+++ b/amrita/plugins/chat/utils/context.py
@@ -12,6 +12,7 @@ from nonebot.adapters.onebot.v11 import GroupMessageEvent, MessageEvent
 from nonebot_plugin_amrita.memory import MemorySchema
 
 from ..config import Config, config_manager
+from ..skills import build_skill_usage_prompt
 
 
 def _format_desc_xml() -> str:
@@ -91,6 +92,7 @@ def build_train_dict(
             if config.function.allow_custom_prompt
             else ""
         )
+        + build_skill_usage_prompt()
     )
     return {"role": "system", "content": train_content}
 

--- a/amrita/plugins/chat/utils/preset.py
+++ b/amrita/plugins/chat/utils/preset.py
@@ -12,15 +12,26 @@ from ..config import config_manager
 
 
 async def resolve_preset(
-    name: str | None = None, *, fix: bool = False, cache: bool = True
+    name: str | None = None, *, fix: bool = True, cache: bool = True
 ) -> ModelPreset:
     """解析预设名 → ``ModelPreset``。
 
     Args:
         name: 预设名；``None`` 时取配置选中的预设（``config.preset``）
-        fix: 找不到时修正为 ``default`` 并持久化
+        fix: 找不到时回退（default → 首个可用预设）并持久化选中。
+            默认 ``True``：热路径自动修正失效的选中预设（如 default 被删除）
         cache: 是否走磁盘预设缓存（默认 ``True``，热路径友好）
+
+    Returns:
+        ``ModelPreset``：解析到的预设。``fix=True`` 时回退链保证非空
+        （预设目录为空会自动创建 ``default``）。
+
+    Raises:
+        LookupError: ``fix=False`` 且目标预设不存在
     """
     if name is None:
         name = config_manager.config.preset
-    return await config_manager.presets.get_preset(name, fix=fix, cache=cache)
+    preset = await config_manager.presets.get_preset(name, fix=fix, cache=cache)
+    if preset is None:
+        raise LookupError(f"预设 {name} 不存在")
+    return preset

--- a/amrita/plugins/chat/utils/stream_sender.py
+++ b/amrita/plugins/chat/utils/stream_sender.py
@@ -228,6 +228,10 @@ class ChatStreamSender:
                     if detail:
                         text += f"\n{detail}"
                     await self._matcher.send(text)
+            case "skill_call":
+                # 技能触发通知（由 skills 模块在技能工具被调用时推送）
+                if meta.enable and meta.skill_trigger:
+                    await self._matcher.send(f"🧠 {message.content}")
             case "text":
                 if (
                     extra_type == "structured_reasoning_step"

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -678,7 +678,7 @@ async def update_skills(request: Request):
     except Exception as e:
         logger.opt(exception=e, colors=True, raw=True).error("保存技能配置失败")
         return JSONResponse(
-            {"success": False, "message": f"保存技能配置失败: {e!s}"},
+            {"success": False, "message": "保存技能配置失败"},
             status_code=500,
         )
 

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -93,15 +93,9 @@ async def update_model(request: Request, name: str):
                 # 前端未修改 api_key 时不会提交该键，因此不会误清空
                 setattr(preset, key, value)
 
-        if name == "default":
-            # default 预设即 config.default_preset（运行时模型配置），
-            # 更新后写回配置并持久化（不能存到预设表文件，那里不生效）
-            config_manager.config.default_preset = preset
-            await config_manager.save_config()
-        else:
-            # 保存模型预设到文件
-            preset_path = config_manager.get_preset_path(name)
-            preset.save(preset_path)
+        # 所有预设（含 default）统一以磁盘预设文件承载
+        preset_path = config_manager.get_preset_path(name)
+        preset.save(preset_path)
 
         # 重新加载模型列表
         await config_manager.get_all_presets(cache=False)
@@ -122,13 +116,8 @@ async def update_model(request: Request, name: str):
 @router.post("/api/chat/models/{name}/delete")
 async def delete_model(name: str):
     try:
-        # default 预设是运行时配置（config.default_preset），不可删除
-        if name == "default":
-            return JSONResponse(
-                {"success": False, "message": "默认预设不可删除"},
-                status_code=400,
-            )
-
+        # default 预设与普通预设一致（磁盘文件），可删除；
+        # 若删除的是配置选中的预设，重置选中到剩余的第一个预设。
         preset_path = config_manager.get_preset_path(name)
 
         if not preset_path.exists():
@@ -141,6 +130,13 @@ async def delete_model(name: str):
         # 重新加载模型列表
         await config_manager.get_all_presets(cache=False)
         config_manager.forget_preset(name)
+
+        # 删除的是当前选中的预设 → 重置选中到剩余第一个可用预设
+        if config_manager.config.preset == name:
+            remaining = await config_manager.get_all_presets(cache=False)
+            if remaining:
+                config_manager.ins_config.preset = remaining[0].name
+                await config_manager.save_config()
 
         return JSONResponse(
             {"success": True, "message": f"模型预设 {name} 删除成功"}, status_code=200

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -699,6 +699,6 @@ async def reload_skills_api():
     except Exception as e:
         logger.opt(exception=e, colors=True, raw=True).error("重载技能失败")
         return JSONResponse(
-            {"success": False, "message": f"重载技能失败: {e!s}"},
+            {"success": False, "message": "重载技能失败，请稍后重试"},
             status_code=500,
         )

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -54,7 +54,7 @@ async def create_model(request: Request):
     except Exception as e:
         logger.opt(exception=e, colors=True, raw=True).error("创建模型预设失败")
         return JSONResponse(
-            {"success": False, "message": f"创建模型预设失败: {e!s}"},
+            {"success": False, "message": "创建模型预设失败"},
             status_code=500,
         )
 
@@ -109,7 +109,7 @@ async def update_model(request: Request, name: str):
             "[webui] 模型预设更新失败: %s", e
         )
         return JSONResponse(
-            {"success": False, "message": f"更新模型预设失败: {e!s}"},
+            {"success": False, "message": "更新模型预设失败"},
             status_code=500,
         )
 
@@ -147,7 +147,7 @@ async def delete_model(name: str):
             f"Error in delete preset {name}"
         )
         return JSONResponse(
-            {"success": False, "message": f"删除模型预设失败: {e!s}"},
+            {"success": False, "message": "删除模型预设失败"},
             status_code=500,
         )
 
@@ -171,7 +171,7 @@ async def get_models():
     except Exception as e:
         logger.opt(exception=e, colors=True, raw=True).error("获取模型预设列表失败")
         return JSONResponse(
-            {"success": False, "message": f"获取模型预设列表失败: {e!s}"},
+            {"success": False, "message": "获取模型预设列表失败"},
             status_code=500,
         )
 
@@ -220,9 +220,9 @@ async def create_prompt(request: Request, prompt_type: str):
             {"success": True, "message": f"{prompt_type}提示词 {name} 创建成功"},
             status_code=200,
         )
-    except Exception as e:
+    except Exception:
         return JSONResponse(
-            {"success": False, "message": f"创建提示词失败: {e!s}"}, status_code=500
+            {"success": False, "message": "创建提示词失败"}, status_code=500
         )
 
 
@@ -305,9 +305,9 @@ async def update_prompt(request: Request, prompt_type: str, name: str):
             {"success": True, "message": f"{prompt_type}提示词 {name} 更新成功"},
             status_code=200,
         )
-    except Exception as e:
+    except Exception:
         return JSONResponse(
-            {"success": False, "message": f"更新提示词失败: {e!s}"}, status_code=500
+            {"success": False, "message": "更新提示词失败"}, status_code=500
         )
 
 
@@ -351,9 +351,9 @@ async def delete_prompt(prompt_type: str, name: str):
             {"success": True, "message": f"{prompt_type}提示词 {name} 删除成功"},
             status_code=200,
         )
-    except Exception as e:
+    except Exception:
         return JSONResponse(
-            {"success": False, "message": f"删除提示词失败: {e!s}"}, status_code=500
+            {"success": False, "message": "删除提示词失败"}, status_code=500
         )
 
 
@@ -384,9 +384,9 @@ async def get_prompts():
             },
             status_code=200,
         )
-    except Exception as e:
+    except Exception:
         return JSONResponse(
-            {"success": False, "message": f"获取提示词列表失败: {e!s}"},
+            {"success": False, "message": "获取提示词列表失败"},
             status_code=500,
         )
 
@@ -656,7 +656,7 @@ async def get_skills():
     except Exception as e:
         logger.opt(exception=e, colors=True, raw=True).error("获取技能列表失败")
         return JSONResponse(
-            {"success": False, "message": f"获取技能列表失败: {e!s}"},
+            {"success": False, "message": "获取技能列表失败"},
             status_code=500,
         )
 

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -9,7 +9,8 @@ from fastapi import Request
 from nonebot import logger
 from nonebot_plugin_amrita.database import InsightsModel
 
-from amrita.plugins.chat.config import config_manager
+from amrita.plugins.chat.config import SkillConfig, config_manager
+from amrita.plugins.chat.skills import reload_skills, validate_skills
 from amrita.plugins.webui.API import JSONResponse
 from amrita.plugins.webui.API import app as router
 
@@ -618,5 +619,88 @@ async def get_chat_insights():
         logger.opt(exception=e, colors=True, raw=True).error("获取信息统计失败")
         return JSONResponse(
             {"success": False, "message": "获取信息统计失败"},
+            status_code=500,
+        )
+
+
+@router.get("/api/chat/skills")
+async def get_skills():
+    """技能管理：已发现技能（含启停/校验状态）与启停配置。"""
+    try:
+        results = validate_skills()
+        config = config_manager.ins_config.skills
+        return JSONResponse(
+            {
+                "success": True,
+                "data": {
+                    "skills": [
+                        {
+                            "name": r.name,
+                            "description": r.description,
+                            "version": r.version,
+                            "path": r.path,
+                            "enabled": r.enabled,
+                            "ok": r.ok,
+                            "error": r.error,
+                        }
+                        for r in results
+                    ],
+                    "config": {
+                        "enable": config.enable,
+                        "enabled": config.enabled,
+                        "disabled": config.disabled,
+                    },
+                },
+            },
+            status_code=200,
+        )
+    except Exception as e:
+        logger.opt(exception=e, colors=True, raw=True).error("获取技能列表失败")
+        return JSONResponse(
+            {"success": False, "message": f"获取技能列表失败: {e!s}"},
+            status_code=500,
+        )
+
+
+@router.post("/api/chat/skills")
+async def update_skills(request: Request):
+    """技能启停配置保存（全量覆盖 enable/enabled/disabled）。"""
+    try:
+        data: dict[str, Any] = await request.json()
+        skills_cfg = SkillConfig(
+            enable=bool(data.get("enable", True)),
+            enabled=[str(x) for x in data.get("enabled", [])],
+            disabled=[str(x) for x in data.get("disabled", [])],
+        )
+        config_manager.ins_config.skills = skills_cfg
+        await config_manager.save_config()
+        return JSONResponse(
+            {"success": True, "message": "技能配置保存成功"}, status_code=200
+        )
+    except Exception as e:
+        logger.opt(exception=e, colors=True, raw=True).error("保存技能配置失败")
+        return JSONResponse(
+            {"success": False, "message": f"保存技能配置失败: {e!s}"},
+            status_code=500,
+        )
+
+
+@router.post("/api/chat/skills/actions/reload")
+async def reload_skills_api():
+    """重新发现并校验技能目录（拾取新增/修改的 SKILL.md）。"""
+    try:
+        results = reload_skills()
+        return JSONResponse(
+            {
+                "success": True,
+                "message": "技能重载成功",
+                "data": {"count": len(results)},
+            },
+            status_code=200,
+        )
+    except Exception as e:
+        logger.opt(exception=e, colors=True, raw=True).error("重载技能失败")
+        return JSONResponse(
+            {"success": False, "message": f"重载技能失败: {e!s}"},
             status_code=500,
         )

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -13,8 +13,6 @@ from amrita.plugins.chat.config import config_manager
 from amrita.plugins.webui.API import JSONResponse
 from amrita.plugins.webui.API import app as router
 
-KEY_PLACEHOLDER = "••••••••"
-
 
 @router.post("/api/chat/models")
 async def create_model(request: Request):
@@ -90,10 +88,9 @@ async def update_model(request: Request, name: str):
                     for tc_key, tc_value in value.items():
                         if hasattr(preset.thinking_config, tc_key):
                             setattr(preset.thinking_config, tc_key, tc_value)
-            elif key == "api_key":
-                if value != KEY_PLACEHOLDER:
-                    setattr(preset, key, value)
             elif hasattr(preset, key) and key != "name":  # 排除不可变的name字段
+                # PATCH 语义：payload 中出现才更新（含 api_key）——
+                # 前端未修改 api_key 时不会提交该键，因此不会误清空
                 setattr(preset, key, value)
 
         if name == "default":
@@ -164,8 +161,12 @@ async def get_models():
         models = copy.deepcopy(await config_manager.get_all_presets(cache=False))
         model_data = []
         for model in models:
-            model.api_key = KEY_PLACEHOLDER
-            model_data.append(model.model_dump())
+            # 敏感字段不回传：api_key 置空，仅暴露是否已配置
+            has_key = bool(model.api_key)
+            model.api_key = ""
+            dump = model.model_dump()
+            dump["has_api_key"] = has_key
+            model_data.append(dump)
 
         return JSONResponse(
             {"success": True, "data": {"models": model_data}}, status_code=200

--- a/amrita/plugins/chat/webui/page.py
+++ b/amrita/plugins/chat/webui/page.py
@@ -627,7 +627,7 @@ async def get_chat_insights():
 async def get_skills():
     """技能管理：已发现技能（含启停/校验状态）与启停配置。"""
     try:
-        results = validate_skills()
+        results = await validate_skills()
         config = config_manager.ins_config.skills
         return JSONResponse(
             {
@@ -647,8 +647,7 @@ async def get_skills():
                     ],
                     "config": {
                         "enable": config.enable,
-                        "enabled": config.enabled,
-                        "disabled": config.disabled,
+                        "selected": config.selected,
                     },
                 },
             },
@@ -664,13 +663,12 @@ async def get_skills():
 
 @router.post("/api/chat/skills")
 async def update_skills(request: Request):
-    """技能启停配置保存（全量覆盖 enable/enabled/disabled）。"""
+    """技能启停配置保存（全量覆盖 enable/selected）。"""
     try:
         data: dict[str, Any] = await request.json()
         skills_cfg = SkillConfig(
             enable=bool(data.get("enable", True)),
-            enabled=[str(x) for x in data.get("enabled", [])],
-            disabled=[str(x) for x in data.get("disabled", [])],
+            selected=[str(x) for x in data.get("selected", [])],
         )
         config_manager.ins_config.skills = skills_cfg
         await config_manager.save_config()
@@ -689,7 +687,7 @@ async def update_skills(request: Request):
 async def reload_skills_api():
     """重新发现并校验技能目录（拾取新增/修改的 SKILL.md）。"""
     try:
-        results = reload_skills()
+        results = await reload_skills()
         return JSONResponse(
             {
                 "success": True,

--- a/amrita/plugins/webui/service/config.py
+++ b/amrita/plugins/webui/service/config.py
@@ -46,6 +46,27 @@ class WsConfig(BaseModel):
         default=64 * 1024,
         description="从日志文件尾部读取时每次 seek 的块大小（字节）",
     )
+    log_replay_batch: int = Field(
+        default=20,
+        description=(
+            "日志回放每批发送条数（批间让出事件循环，实时日志可插队，"
+            "避免回放历史时实时日志长时间滞后）"
+        ),
+    )
+    allowed_origins: list[str] = Field(
+        default_factory=list,
+        description=(
+            "WebSocket 额外允许的 Origin（同源请求自动放行，无需配置；"
+            "用于反代等 Host 与 Origin hostname 不一致的部署，留空表示仅允许同站）"
+        ),
+    )
+    auth_check_interval: float = Field(
+        default=60.0,
+        description=(
+            "WS 连接内定期复检登录态的时间间隔（秒）：token 过期/登出后"
+            "断开挂机连接，避免长连接长期有效"
+        ),
+    )
 
 
 # 配置热重载钩子

--- a/amrita/plugins/webui/service/config.py
+++ b/amrita/plugins/webui/service/config.py
@@ -12,7 +12,6 @@ from pydantic import BaseModel, Field
 DEFAULT_WEBUI_PASSWORD = "admin123"
 
 
-
 class Config(BaseModel):
     """
     Configuration for webui
@@ -32,12 +31,8 @@ def get_webui_config() -> Config:
 class WsConfig(BaseModel):
     """WebSocket 实时推送配置（/amrita/ui/ws 频道）"""
 
-    system_interval: float = Field(
-        default=2.0, description="system 频道推送间隔（秒）"
-    )
-    bot_state_interval: float = Field(
-        default=5.0, description="bot 状态检查间隔（秒）"
-    )
+    system_interval: float = Field(default=2.0, description="system 频道推送间隔（秒）")
+    bot_state_interval: float = Field(default=5.0, description="bot 状态检查间隔（秒）")
     log_pending_max: int = Field(
         default=5000, description="待广播日志队列上限（sink 线程写、dispatcher 消费）"
     )
@@ -51,10 +46,13 @@ class WsConfig(BaseModel):
         default=64 * 1024,
         description="从日志文件尾部读取时每次 seek 的块大小（字节）",
     )
+
+
 # 配置热重载钩子
 
 WsConfigReloadHook = Callable[[WsConfig], Awaitable[None]]
 _reload_hooks: list[WsConfigReloadHook] = []
+
 
 def register_ws_config_reload_hook(hook: WsConfigReloadHook) -> None:
     """注册配置热重载钩子（幂等，重复注册自动去重）。"""
@@ -106,13 +104,16 @@ class DataManager(BaseDataManager[WsConfig]):
             self._task = asyncio.create_task(init())
             self._inited = True
 
+
 def is_using_default_password() -> bool:
     """是否仍在使用出厂默认密码（此时 WebUI 锁定，要求更换）。"""
     return get_webui_config().webui_password.strip() == DEFAULT_WEBUI_PASSWORD
+
 
 @get_driver().on_startup
 async def _() -> None:
     """启动时加载配置。"""
     await data_manager.safe_get_config()
+
 
 data_manager = DataManager()

--- a/amrita/plugins/webui/service/config.py
+++ b/amrita/plugins/webui/service/config.py
@@ -62,9 +62,10 @@ class WsConfig(BaseModel):
     )
     auth_check_interval: float = Field(
         default=60.0,
+        gt=0,
         description=(
-            "WS 连接内定期复检登录态的时间间隔（秒）：token 过期/登出后"
-            "断开挂机连接，避免长连接长期有效"
+            "WS 连接内定期复检登录态的时间间隔（秒，必须为正数）：token "
+            "过期/登出后断开挂机连接，避免长连接长期有效"
         ),
     )
 

--- a/amrita/plugins/webui/service/route/menu.py
+++ b/amrita/plugins/webui/service/route/menu.py
@@ -140,6 +140,13 @@ _CORE_ROUTES = [
         "icon": "server",
         "hidden": False,
     },
+    {
+        "path": "/manage/chat/skills",
+        "name": "技能管理",
+        "category": "聊天管理",
+        "icon": "wand-2",
+        "hidden": False,
+    },
 ]
 
 

--- a/amrita/plugins/webui/service/ws.py
+++ b/amrita/plugins/webui/service/ws.py
@@ -467,9 +467,7 @@ async def websocket_endpoint(ws: WebSocket) -> None:
                 opts = raw.get("opts") or {}
                 logs_opts = opts.get("logs") or {}
                 try:
-                    logs_limit = int(
-                        logs_opts.get("limit", cfg.log_replay_limit)
-                    )
+                    logs_limit = int(logs_opts.get("limit", cfg.log_replay_limit))
                 except (TypeError, ValueError):
                     logs_limit = cfg.log_replay_limit
                 logs_limit = min(max(logs_limit, 1), cfg.log_replay_limit_max)

--- a/amrita/plugins/webui/service/ws.py
+++ b/amrita/plugins/webui/service/ws.py
@@ -25,6 +25,7 @@ from collections.abc import Coroutine
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TextIO
+from urllib.parse import urlsplit
 
 import aiofiles
 import nonebot
@@ -84,6 +85,52 @@ class ChannelHub:
 
 
 hub = ChannelHub()
+
+
+def _origin_matches_host(origin: str, host: str) -> bool:
+    """Origin 与请求 Host 是否同「站点」（hostname 一致，端口不限）。
+
+    与浏览器 SameSite 的 site 判定一致（同 hostname 不同端口视为同站）：
+    仅跨 hostname 的 Origin 才需要走白名单。IPv6 字面量（[::1]:port）也支持。
+    """
+    try:
+        parts = urlsplit(origin)
+    except ValueError:
+        return False
+    if parts.scheme not in ("http", "https") or parts.hostname is None:
+        return False
+    host_l = host.lower()
+    if host_l.startswith("["):  # IPv6 字面量
+        end = host_l.find("]")
+        if end == -1:
+            return False
+        host_name = host_l[1:end]
+    elif ":" in host_l:
+        host_name, _, _ = host_l.rpartition(":")
+    else:
+        host_name = host_l
+    return parts.hostname.lower() == host_name
+
+
+def _origin_allowed(origin: str | None, host: str | None, cfg: WsConfig) -> bool:
+    """WebSocket 握手 Origin 校验：同站自动放行；跨站查白名单。
+
+    Origin 缺失（非浏览器客户端，如脚本/curl）放行——此类客户端不会被
+    浏览器自动携带 cookie，跨站 WebSocket 劫持面不成立。
+    """
+    if origin is None:
+        return True
+    if host is not None and _origin_matches_host(origin, host):
+        return True
+    return origin in cfg.allowed_origins
+
+
+async def _token_valid(token: str | None) -> bool:
+    """token 是否仍有效（存在且未过期）。"""
+    if token is None:
+        return False
+    token_data = await TokenManager().get_token_data(token, None)
+    return token_data is not None and token_data.expire >= datetime.now(utc)
 
 
 async def _send_json_locked(ws: WebSocket, message: dict) -> None:
@@ -344,34 +391,52 @@ async def _read_log_tail(limit: int) -> list[dict[str, Any]]:
         logger.debug("读取实时日志尾部失败", exc_info=True)
         return []
 
+async def _flush_replay_batch(ws: WebSocket, batch: list[dict[str, Any]]) -> None:
+    """逐条发送一批回放消息（持锁，与 dispatcher 广播串行）。"""
+    for message in batch:
+        await _send_json_locked(ws, message)
+
 
 async def _send_log_replay(ws: WebSocket, limit: int | None = None) -> None:
     """订阅 logs 时回放本次启动以来**最后 limit 条**日志（tail 语义）。
 
-    不全量回放：长运行的 Bot 可能产生数万条日志，全量回放会一次性
-    压垮前端（UI 卡死）。只发送文件尾部最新 limit 条，按时间正序发送。
-    limit 为 None 时使用配置 log_replay_limit。
+    由调用方以后台任务方式执行（不阻塞订阅循环）；按批发送并在批间
+    让出事件循环，实时日志（dispatcher）可插队——先快速看到最近 N 条
+    历史，随后无缝跟随实时。批次大小由配置 ``log_replay_batch`` 控制
+    （asyncio.Lock 为 FIFO，dispatcher 在锁队列中优先于下一批回放获得
+    发送权）。连接断开时静默结束（订阅循环的 finally 负责清理），
+    失败仅留 debug 线索。
     """
-    if limit is None:
+    try:
         cfg = await data_manager.safe_get_config()
-        limit = cfg.log_replay_limit
-    for item in await _read_log_tail(limit):
-        level = item.get("level", "INFO")
-        color, icon = _LEVEL_META.get(level, ("blue", "code"))
-        # 持锁发送：与 dispatcher 广播串行，避免并发 send 导致连接异常
-        await _send_json_locked(
-            ws,
-            {
-                "channel": "logs",
-                "data": {
-                    "title": level,
-                    "desc": item.get("payload", ""),
-                    "time": item.get("time", ""),
-                    "icon_color": color,
-                    "icon": icon,
-                },
-            },
-        )
+        if limit is None:
+            limit = cfg.log_replay_limit
+        batch: list[dict[str, Any]] = []
+        for item in await _read_log_tail(limit):
+            level = item.get("level", "INFO")
+            color, icon = _LEVEL_META.get(level, ("blue", "code"))
+            batch.append(
+                {
+                    "channel": "logs",
+                    "data": {
+                        "title": level,
+                        "desc": item.get("payload", ""),
+                        "time": item.get("time", ""),
+                        "icon_color": color,
+                        "icon": icon,
+                    },
+                }
+            )
+            if len(batch) >= cfg.log_replay_batch:
+                await _flush_replay_batch(ws, batch)
+                batch = []
+                # 让出事件循环：实时日志（dispatcher）在锁队列中优先发送
+                await asyncio.sleep(0)
+        if batch:
+            await _flush_replay_batch(ws, batch)
+    except Exception:
+        # 连接断开/发送失败：静默结束，不产生未捕获异常告警
+        logger.debug("日志回放中断", exc_info=True)
 
 
 _started = False
@@ -443,14 +508,17 @@ async def websocket_endpoint(ws: WebSocket) -> None:
     """WebSocket 端点：先认证，再按订阅推送。"""
     await ws.accept()
 
+    # Origin 校验（防跨站 WebSocket 劫持：同站自动放行，跨站查白名单）
+    cfg = await data_manager.safe_get_config()
+    if not _origin_allowed(
+        ws.headers.get("origin"), ws.headers.get("host"), cfg
+    ):
+        await ws.close(code=1008, reason="Origin 不被允许")
+        return
+
     # Cookie 认证（WebSocket 无法重定向，直接关闭）
     token = ws.cookies.get(TOKEN_KEY)
-    token_manager = TokenManager()
-    if not token:
-        await ws.close(code=4401, reason="未授权")
-        return
-    token_data = await token_manager.get_token_data(token, None)
-    if token_data is None or token_data.expire < datetime.now(utc):
+    if not await _token_valid(token):
         await ws.close(code=4401, reason="未授权")
         return
 
@@ -459,7 +527,17 @@ async def websocket_endpoint(ws: WebSocket) -> None:
     channels: set[str] = set()
     try:
         while True:
-            raw = await ws.receive_json()
+            cfg = await data_manager.safe_get_config()
+            try:
+                raw = await asyncio.wait_for(
+                    ws.receive_json(), timeout=cfg.auth_check_interval
+                )
+            except asyncio.TimeoutError:
+                # 周期性复检登录态：登出/token 过期后断开挂机连接
+                if not await _token_valid(token):
+                    await ws.close(code=4401, reason="未授权")
+                    return
+                continue
             action = raw.get("action")
             if action == "subscribe":
                 # 前端可控制日志回放条数：{"action":"subscribe","channels":["logs"],"opts":{"logs":{"limit":N}}}
@@ -474,8 +552,12 @@ async def websocket_endpoint(ws: WebSocket) -> None:
                 for ch in raw.get("channels", []):
                     if ch in ("system", "bot", "logs"):
                         if ch == "logs" and ch not in channels:
-                            # 首次订阅 logs：回放本次启动以来最后 logs_limit 条
-                            await _send_log_replay(ws, logs_limit)
+                            # 首次订阅 logs：后台回放本次启动以来最后 logs_limit 条
+                            # （tail 语义）。回放放后台任务：同步逐条发送会阻塞
+                            # 订阅循环（无法处理 ping/退订），且实时日志（dispatcher）
+                            # 被回放占锁直到回放结束——回放量大时前端长时间只
+                            # 看到历史、实时日志滞后（“卡半天”）。
+                            _spawn_background(_send_log_replay(ws, logs_limit))
                         elif ch not in channels:
                             # 首次订阅 bot/system：立即推当前状态快照，
                             # 避免新订阅者要等下一次变化才能拿到数据；

--- a/amrita/plugins/webui/service/ws.py
+++ b/amrita/plugins/webui/service/ws.py
@@ -21,7 +21,7 @@ import os
 import threading
 import weakref
 from collections import deque
-from collections.abc import Coroutine
+from collections.abc import Callable, Coroutine
 from datetime import datetime
 from pathlib import Path
 from typing import Any, TextIO
@@ -87,42 +87,46 @@ class ChannelHub:
 hub = ChannelHub()
 
 
-def _origin_matches_host(origin: str, host: str) -> bool:
-    """Origin 与请求 Host 是否同「站点」（hostname 一致，端口不限）。
+def _origin_components(origin: str) -> tuple[str, str, int] | None:
+    """解析 Origin（scheme://host:port）为可比较的 (scheme, hostname, port)。
 
-    与浏览器 SameSite 的 site 判定一致（同 hostname 不同端口视为同站）：
-    仅跨 hostname 的 Origin 才需要走白名单。IPv6 字面量（[::1]:port）也支持。
+    端口缺省按 scheme 归一（http→80、https→443）；非法/非 http(s) 返回
+    None。hostname 统一小写；IPv6 字面量（[::1]:8080）由 urlsplit 处理。
     """
     try:
         parts = urlsplit(origin)
     except ValueError:
-        return False
+        return None
     if parts.scheme not in ("http", "https") or parts.hostname is None:
-        return False
-    host_l = host.lower()
-    if host_l.startswith("["):  # IPv6 字面量
-        end = host_l.find("]")
-        if end == -1:
-            return False
-        host_name = host_l[1:end]
-    elif ":" in host_l:
-        host_name, _, _ = host_l.rpartition(":")
-    else:
-        host_name = host_l
-    return parts.hostname.lower() == host_name
+        return None
+    default_port = 443 if parts.scheme == "https" else 80
+    return (parts.scheme, parts.hostname.lower(), parts.port or default_port)
 
 
-def _origin_allowed(origin: str | None, host: str | None, cfg: WsConfig) -> bool:
-    """WebSocket 握手 Origin 校验：同站自动放行；跨站查白名单。
+def _origin_allowed(
+    origin: str | None, host: str | None, ws_scheme: str, cfg: WsConfig
+) -> bool:
+    """WebSocket 握手 Origin 校验：精确同源，否则查白名单。
 
-    Origin 缺失（非浏览器客户端，如脚本/curl）放行——此类客户端不会被
-    浏览器自动携带 cookie，跨站 WebSocket 劫持面不成立。
+    - Origin 缺失（非浏览器客户端，如脚本/curl）放行——此类客户端不会被
+      浏览器自动携带 cookie，跨站 WebSocket 劫持面不成立
+    - 精确同源：Origin（http/https）与本次连接（ws/wss）的
+      scheme/hostname/port 逐一相等——不同端口/协议不视为同源，
+      避免同 hostname 上的其他服务借道窃取认证数据
+    - 跨源必须命中 allowed_origins（scheme://host:port 精确匹配，含端口），
+      如反代、开发服务器等场景
     """
     if origin is None:
         return True
-    if host is not None and _origin_matches_host(origin, host):
-        return True
-    return origin in cfg.allowed_origins
+    page = _origin_components(origin)
+    if page is None:
+        return False
+    if host is not None:
+        conn_scheme = "https" if ws_scheme == "wss" else "http"
+        conn = _origin_components(f"{conn_scheme}://{host}")
+        if conn is not None and conn == page:
+            return True
+    return any(_origin_components(entry) == page for entry in cfg.allowed_origins)
 
 
 async def _token_valid(token: str | None) -> bool:
@@ -391,21 +395,28 @@ async def _read_log_tail(limit: int) -> list[dict[str, Any]]:
         logger.debug("读取实时日志尾部失败", exc_info=True)
         return []
 
+
 async def _flush_replay_batch(ws: WebSocket, batch: list[dict[str, Any]]) -> None:
     """逐条发送一批回放消息（持锁，与 dispatcher 广播串行）。"""
     for message in batch:
         await _send_json_locked(ws, message)
 
 
-async def _send_log_replay(ws: WebSocket, limit: int | None = None) -> None:
+async def _send_log_replay(
+    ws: WebSocket,
+    limit: int | None = None,
+    *,
+    is_subscribed: Callable[[], bool] | None = None,
+) -> None:
     """订阅 logs 时回放本次启动以来**最后 limit 条**日志（tail 语义）。
 
     由调用方以后台任务方式执行（不阻塞订阅循环）；按批发送并在批间
     让出事件循环，实时日志（dispatcher）可插队——先快速看到最近 N 条
     历史，随后无缝跟随实时。批次大小由配置 ``log_replay_batch`` 控制
     （asyncio.Lock 为 FIFO，dispatcher 在锁队列中优先于下一批回放获得
-    发送权）。连接断开时静默结束（订阅循环的 finally 负责清理），
-    失败仅留 debug 线索。
+    发送权）。每批前通过 ``is_subscribed`` 复检订阅状态：客户端退订 logs
+    后立即停止，不再发送历史日志。连接断开时静默结束（订阅循环的
+    finally 负责清理），失败仅留 debug 线索。
     """
     try:
         cfg = await data_manager.safe_get_config()
@@ -413,6 +424,8 @@ async def _send_log_replay(ws: WebSocket, limit: int | None = None) -> None:
             limit = cfg.log_replay_limit
         batch: list[dict[str, Any]] = []
         for item in await _read_log_tail(limit):
+            if is_subscribed is not None and not is_subscribed():
+                return  # 已退订 logs：停止回放（未发送的批次直接丢弃）
             level = item.get("level", "INFO")
             color, icon = _LEVEL_META.get(level, ("blue", "code"))
             batch.append(
@@ -508,10 +521,10 @@ async def websocket_endpoint(ws: WebSocket) -> None:
     """WebSocket 端点：先认证，再按订阅推送。"""
     await ws.accept()
 
-    # Origin 校验（防跨站 WebSocket 劫持：同站自动放行，跨站查白名单）
+    # Origin 校验（防跨站 WebSocket 劫持：精确同源，跨源查白名单）
     cfg = await data_manager.safe_get_config()
     if not _origin_allowed(
-        ws.headers.get("origin"), ws.headers.get("host"), cfg
+        ws.headers.get("origin"), ws.headers.get("host"), ws.url.scheme, cfg
     ):
         await ws.close(code=1008, reason="Origin 不被允许")
         return
@@ -528,10 +541,12 @@ async def websocket_endpoint(ws: WebSocket) -> None:
     try:
         while True:
             cfg = await data_manager.safe_get_config()
+            # 配置为 ≤0 时视为「不复检」：timeout 置 None（永久等待），避免
+            # 0/负值导致每次迭代立即超时的空转（pydantic gt=0 已拦截，这里
+            # 兜底防御热重载等旁路路径）
+            timeout = cfg.auth_check_interval if cfg.auth_check_interval > 0 else None
             try:
-                raw = await asyncio.wait_for(
-                    ws.receive_json(), timeout=cfg.auth_check_interval
-                )
+                raw = await asyncio.wait_for(ws.receive_json(), timeout=timeout)
             except asyncio.TimeoutError:
                 # 周期性复检登录态：登出/token 过期后断开挂机连接
                 if not await _token_valid(token):
@@ -557,7 +572,13 @@ async def websocket_endpoint(ws: WebSocket) -> None:
                             # 订阅循环（无法处理 ping/退订），且实时日志（dispatcher）
                             # 被回放占锁直到回放结束——回放量大时前端长时间只
                             # 看到历史、实时日志滞后（“卡半天”）。
-                            _spawn_background(_send_log_replay(ws, logs_limit))
+                            _spawn_background(
+                                _send_log_replay(
+                                    ws,
+                                    logs_limit,
+                                    is_subscribed=lambda: "logs" in channels,
+                                )
+                            )
                         elif ch not in channels:
                             # 首次订阅 bot/system：立即推当前状态快照，
                             # 避免新订阅者要等下一次变化才能拿到数据；

--- a/frontend/src/hooks/use-ws.ts
+++ b/frontend/src/hooks/use-ws.ts
@@ -191,10 +191,12 @@ function connect() {
         // 回放与实时推送的重叠只会出现在边界；截断防无限增长
         const ev = msg.data as LogEvent;
         const logs = global.snapshots.logs;
-        const dup = logs.slice(-10).some(
-          (l) =>
-            l.time === ev.time && l.title === ev.title && l.desc === ev.desc,
-        );
+        const dup = logs
+          .slice(-10)
+          .some(
+            (l) =>
+              l.time === ev.time && l.title === ev.title && l.desc === ev.desc,
+          );
         if (!dup) {
           updateSnapshot("logs", [...logs, ev].slice(-MAX_LOG_SNAPSHOT));
         }

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -176,8 +176,8 @@ export interface SkillInfo {
 }
 export interface SkillConfig {
   enable: boolean;
-  enabled: string[];
-  disabled: string[];
+  /** 启用的技能名称列表（空列表=全部启用；非空则仅列表内的技能启用） */
+  selected: string[];
 }
 export interface SkillsData {
   skills: SkillInfo[];

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -141,6 +141,8 @@ export interface ChatModel {
   model: string;
   base_url: string;
   api_key: string;
+  /** 是否已配置 API Key（敏感字段不回传，仅暴露状态） */
+  has_api_key?: boolean;
   protocol: string;
   config: Record<string, unknown>;
   thinking_config: Record<string, unknown> | null;

--- a/frontend/src/lib/types.ts
+++ b/frontend/src/lib/types.ts
@@ -165,6 +165,24 @@ export interface McpServer {
 export interface McpServersData {
   servers: McpServer[];
 }
+export interface SkillInfo {
+  name: string;
+  description: string;
+  version: string | null;
+  path: string;
+  enabled: boolean;
+  ok: boolean;
+  error: string | null;
+}
+export interface SkillConfig {
+  enable: boolean;
+  enabled: string[];
+  disabled: string[];
+}
+export interface SkillsData {
+  skills: SkillInfo[];
+  config: SkillConfig;
+}
 export interface ChatInsightsData {
   token_prompt: number;
   token_completion: number;

--- a/frontend/src/pages/manage/models.tsx
+++ b/frontend/src/pages/manage/models.tsx
@@ -25,13 +25,12 @@ import {
   SelectValue,
 } from "@/components/ui/select";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Badge } from "@/components/ui/badge";
 import { ConfirmDialog } from "@/components/shared/ConfirmDialog";
 
 interface ModelRow extends ChatModel {
   __editing?: boolean;
 }
-
-const KEY_PLACEHOLDER = "••••••••";
 
 /** 思考模式配置（对应后端 ThinkingConfig） */
 const THINKING_EFFORT_OPTIONS = [
@@ -60,9 +59,10 @@ function ModelForm({
   const [name, setName] = useState(initial?.name ?? "");
   const [model, setModel] = useState(initial?.model ?? "");
   const [baseUrl, setBaseUrl] = useState(initial?.base_url ?? "");
-  const [apiKey, setApiKey] = useState(
-    initial && initial.api_key !== KEY_PLACEHOLDER ? initial.api_key : "",
-  );
+  // API Key 敏感字段不回传，输入框始终从空开始；
+  // apiKeyTouched 记录用户是否修改过，未修改则提交时省略该键（PATCH 语义）
+  const [apiKey, setApiKey] = useState("");
+  const [apiKeyTouched, setApiKeyTouched] = useState(false);
   const [protocol, setProtocol] = useState(initial?.protocol ?? "__main__");
 
   // 思考模式配置（ThinkingConfig）
@@ -95,6 +95,20 @@ function ModelForm({
     return cfg;
   }
 
+  /** 构建提交 payload：编辑时未修改的 api_key 不提交，避免覆盖已有值 */
+  function buildPayload(): Record<string, unknown> {
+    const payload: Record<string, unknown> = {
+      name,
+      model,
+      base_url: baseUrl,
+      protocol,
+      thinking_config: buildThinkingConfig(),
+    };
+    // 新建：始终提交（可为空）；编辑：仅当用户修改过才提交
+    if (!initial || apiKeyTouched) payload.api_key = apiKey;
+    return payload;
+  }
+
   return (
     <div className="space-y-4">
       <div className="space-y-2">
@@ -117,9 +131,20 @@ function ModelForm({
         <Label>API Key</Label>
         <Input
           value={apiKey}
-          onChange={(e) => setApiKey(e.target.value)}
-          placeholder={initial ? KEY_PLACEHOLDER : undefined}
+          onChange={(e) => {
+            setApiKey(e.target.value);
+            setApiKeyTouched(true);
+          }}
+          placeholder={
+            initial?.has_api_key ? "已配置，留空则不修改" : undefined
+          }
+          type={apiKeyTouched ? "password" : "text"}
         />
+        {initial?.has_api_key && !apiKeyTouched && (
+          <p className="text-xs text-muted-foreground">
+            已配置 API Key。留空并保存将保持原 Key 不变；如需更换请输入新 Key。
+          </p>
+        )}
       </div>
       <div className="space-y-2">
         <Label>协议</Label>
@@ -193,16 +218,7 @@ function ModelForm({
 
       <DialogFooter>
         <Button
-          onClick={() =>
-            onSubmit({
-              name,
-              model,
-              base_url: baseUrl,
-              api_key: apiKey,
-              protocol,
-              thinking_config: buildThinkingConfig(),
-            })
-          }
+          onClick={() => onSubmit(buildPayload())}
           disabled={!name || !model || submitting}
         >
           {submitting ? "保存中…" : "保存"}
@@ -277,6 +293,16 @@ export function ModelsPage() {
       render: (m) => (
         <span className="text-muted-foreground">{m.base_url}</span>
       ),
+    },
+    {
+      key: "api_key",
+      header: "API Key",
+      render: (m) =>
+        m.has_api_key ? (
+          <Badge variant="secondary">已配置</Badge>
+        ) : (
+          <Badge variant="outline">未配置</Badge>
+        ),
     },
     {
       key: "protocol",
@@ -355,6 +381,7 @@ export function ModelsPage() {
           </DialogHeader>
           {editing && (
             <ModelForm
+              key={editing.name}
               initial={editing}
               onSubmit={(payload) =>
                 updateMutation.mutate({ name: editing.name, payload })

--- a/frontend/src/pages/manage/models.tsx
+++ b/frontend/src/pages/manage/models.tsx
@@ -319,13 +319,12 @@ export function ModelsPage() {
           <Button variant="outline" size="sm" onClick={() => setEditing(m)}>
             编辑
           </Button>
-          {/* default 是运行时配置（config.default_preset），不可删除 */}
+          {/* default 与普通预设一致，可编辑可删除；仅当删除后预设目录为空时才会自动重建 */}
           <Button
             variant="destructive"
             size="sm"
             onClick={() => setDeleting(m)}
-            disabled={deleteMutation.isPending || m.name === "default"}
-            title={m.name === "default" ? "默认预设不可删除" : undefined}
+            disabled={deleteMutation.isPending}
           >
             删除
           </Button>

--- a/frontend/src/pages/manage/skills.tsx
+++ b/frontend/src/pages/manage/skills.tsx
@@ -1,30 +1,18 @@
 import { useEffect, useState } from "react";
 import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
 import { toast } from "sonner";
-import { RefreshCw, Save } from "lucide-react";
+import { RefreshCw } from "lucide-react";
 import { api } from "@/lib/api";
 import type { SkillConfig, SkillInfo, SkillsData } from "@/lib/types";
 import { DataTable, type Column } from "@/components/shared/DataTable";
 import { Badge } from "@/components/ui/badge";
 import { Button } from "@/components/ui/button";
 import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
-import { Label } from "@/components/ui/label";
 import { Switch } from "@/components/ui/switch";
-import { Textarea } from "@/components/ui/textarea";
-
-/** 解析每行一个的文本列表（兼容逗号/换行分隔） */
-function parseList(text: string): string[] {
-  return text
-    .split(/[\n,，]/)
-    .map((s) => s.trim())
-    .filter(Boolean);
-}
 
 export function SkillsPage() {
   const qc = useQueryClient();
   const [enable, setEnable] = useState(true);
-  const [enabledText, setEnabledText] = useState("");
-  const [disabledText, setDisabledText] = useState("");
 
   const { data, isLoading } = useQuery({
     queryKey: ["chat-skills"],
@@ -34,8 +22,6 @@ export function SkillsPage() {
   useEffect(() => {
     if (data?.data) {
       setEnable(data.data.config.enable);
-      setEnabledText(data.data.config.enabled.join("\n"));
-      setDisabledText(data.data.config.disabled.join("\n"));
     }
   }, [data]);
 
@@ -59,32 +45,40 @@ export function SkillsPage() {
 
   const save = (cfg: SkillConfig) => saveMutation.mutate(cfg);
 
-  /** 行内启停切换：更新 disabled（白名单模式下启用时同步加入白名单） */
+  /** 行内启停切换：维护 selected 列表（空=全部启用；非空=仅列表内启用） */
   const toggleSkill = (skill: SkillInfo) => {
     if (!data) return;
     const cfg = data.data.config;
-    const disabledSet = new Set(cfg.disabled);
+    const allNames = data.data.skills.map((s) => s.name);
+    let selected = cfg.selected;
     if (skill.enabled) {
-      disabledSet.add(skill.name);
+      // 禁用：selected 为空时需显式列出其余全部技能；非空时从中移除
+      const others = allNames.filter((n) => n !== skill.name);
+      selected =
+        selected.length === 0 ? others : selected.filter((n) => n !== skill.name);
+    } else if (selected.length === 0) {
+      // 全启用状态下无需修改（所有技能均已启用）
+      return;
     } else {
-      disabledSet.delete(skill.name);
+      // 启用：非空 selected 中加入该技能
+      selected = [...selected, skill.name];
     }
-    let enabledList = cfg.enabled;
-    if (
-      !skill.enabled &&
-      enabledList.length > 0 &&
-      !enabledList.includes(skill.name)
-    ) {
-      enabledList = [...enabledList, skill.name];
-    }
-    save({
-      enable: cfg.enable,
-      enabled: enabledList,
-      disabled: [...disabledSet],
-    });
+    save({ enable: cfg.enable, selected });
   };
 
   const columns: Column<SkillInfo>[] = [
+    {
+      key: "enabled",
+      header: "启用",
+      render: (s) => (
+        <Switch
+          checked={s.enabled}
+          onCheckedChange={() => toggleSkill(s)}
+          disabled={!s.ok || saveMutation.isPending}
+          aria-label={`${s.enabled ? "禁用" : "启用"}技能 ${s.name}`}
+        />
+      ),
+    },
     {
       key: "name",
       header: "名称",
@@ -125,27 +119,16 @@ export function SkillsPage() {
     },
     {
       key: "actions",
-      header: "操作",
-      render: (s) => (
-        <div className="flex items-center gap-3">
-          {!s.ok && s.error && (
-            <span
-              className="max-w-xs truncate text-xs text-destructive"
-              title={s.error}
-            >
-              {s.error}
-            </span>
-          )}
-          <Button
-            variant={s.enabled ? "outline" : "default"}
-            size="sm"
-            onClick={() => toggleSkill(s)}
-            disabled={saveMutation.isPending}
+      header: "",
+      render: (s) =>
+        !s.ok && s.error ? (
+          <span
+            className="max-w-xs truncate text-xs text-destructive"
+            title={s.error}
           >
-            {s.enabled ? "禁用" : "启用"}
-          </Button>
-        </div>
-      ),
+            {s.error}
+          </span>
+        ) : null,
     },
   ];
 
@@ -167,8 +150,7 @@ export function SkillsPage() {
                 if (data) {
                   save({
                     enable: checked,
-                    enabled: data.data.config.enabled,
-                    disabled: data.data.config.disabled,
+                    selected: data.data.config.selected,
                   });
                 }
               }}
@@ -190,52 +172,24 @@ export function SkillsPage() {
 
       <Card>
         <CardHeader>
-          <CardTitle className="text-base">启停配置</CardTitle>
-        </CardHeader>
-        <CardContent className="space-y-4">
-          <div className="grid gap-4 md:grid-cols-2">
-            <div className="space-y-2">
-              <Label>启用白名单（每行一个，留空=全部启用）</Label>
-              <Textarea
-                value={enabledText}
-                onChange={(e) => setEnabledText(e.target.value)}
-                placeholder="skill_name"
-                rows={4}
-                className="font-mono text-xs"
-              />
-            </div>
-            <div className="space-y-2">
-              <Label>禁用黑名单（每行一个，优先级高于白名单）</Label>
-              <Textarea
-                value={disabledText}
-                onChange={(e) => setDisabledText(e.target.value)}
-                placeholder="skill_name"
-                rows={4}
-                className="font-mono text-xs"
-              />
-            </div>
-          </div>
-          <div className="flex justify-end">
+          <div className="flex items-center justify-between">
+            <CardTitle className="text-base">技能列表</CardTitle>
             <Button
-              onClick={() =>
-                save({
-                  enable,
-                  enabled: parseList(enabledText),
-                  disabled: parseList(disabledText),
-                })
-              }
+              variant="outline"
+              size="sm"
+              onClick={() => save({ enable, selected: [] })}
               disabled={saveMutation.isPending}
+              title="清空 selected 列表，恢复全部技能启用"
             >
-              <Save className="mr-1 h-4 w-4" />
-              {saveMutation.isPending ? "保存中…" : "保存配置"}
+              全部启用
             </Button>
           </div>
-        </CardContent>
-      </Card>
-
-      <Card>
-        <CardHeader>
-          <CardTitle className="text-base">技能列表</CardTitle>
+          <p className="text-sm text-muted-foreground">
+            勾选开关 = 启用对应技能；清空启用名单（点击“全部启用”）即全部启用。
+          </p>
+          <p className="text-xs text-muted-foreground/80">
+            （您也可以在配置文件处修改）
+          </p>
         </CardHeader>
         <CardContent>
           <DataTable

--- a/frontend/src/pages/manage/skills.tsx
+++ b/frontend/src/pages/manage/skills.tsx
@@ -1,0 +1,251 @@
+import { useEffect, useState } from "react";
+import { useMutation, useQuery, useQueryClient } from "@tanstack/react-query";
+import { toast } from "sonner";
+import { RefreshCw, Save } from "lucide-react";
+import { api } from "@/lib/api";
+import type { SkillConfig, SkillInfo, SkillsData } from "@/lib/types";
+import { DataTable, type Column } from "@/components/shared/DataTable";
+import { Badge } from "@/components/ui/badge";
+import { Button } from "@/components/ui/button";
+import { Card, CardContent, CardHeader, CardTitle } from "@/components/ui/card";
+import { Label } from "@/components/ui/label";
+import { Switch } from "@/components/ui/switch";
+import { Textarea } from "@/components/ui/textarea";
+
+/** 解析每行一个的文本列表（兼容逗号/换行分隔） */
+function parseList(text: string): string[] {
+  return text
+    .split(/[\n,，]/)
+    .map((s) => s.trim())
+    .filter(Boolean);
+}
+
+export function SkillsPage() {
+  const qc = useQueryClient();
+  const [enable, setEnable] = useState(true);
+  const [enabledText, setEnabledText] = useState("");
+  const [disabledText, setDisabledText] = useState("");
+
+  const { data, isLoading } = useQuery({
+    queryKey: ["chat-skills"],
+    queryFn: () => api.get<SkillsData>("/api/chat/skills"),
+  });
+
+  useEffect(() => {
+    if (data?.data) {
+      setEnable(data.data.config.enable);
+      setEnabledText(data.data.config.enabled.join("\n"));
+      setDisabledText(data.data.config.disabled.join("\n"));
+    }
+  }, [data]);
+
+  const reloadMutation = useMutation({
+    mutationFn: () => api.post("/api/chat/skills/actions/reload"),
+    onSuccess: (res) => {
+      toast.success(res.message);
+      void qc.invalidateQueries({ queryKey: ["chat-skills"] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const saveMutation = useMutation({
+    mutationFn: (cfg: SkillConfig) => api.post("/api/chat/skills", cfg),
+    onSuccess: (res) => {
+      toast.success(res.message);
+      void qc.invalidateQueries({ queryKey: ["chat-skills"] });
+    },
+    onError: (e: Error) => toast.error(e.message),
+  });
+
+  const save = (cfg: SkillConfig) => saveMutation.mutate(cfg);
+
+  /** 行内启停切换：更新 disabled（白名单模式下启用时同步加入白名单） */
+  const toggleSkill = (skill: SkillInfo) => {
+    if (!data) return;
+    const cfg = data.data.config;
+    const disabledSet = new Set(cfg.disabled);
+    if (skill.enabled) {
+      disabledSet.add(skill.name);
+    } else {
+      disabledSet.delete(skill.name);
+    }
+    let enabledList = cfg.enabled;
+    if (
+      !skill.enabled &&
+      enabledList.length > 0 &&
+      !enabledList.includes(skill.name)
+    ) {
+      enabledList = [...enabledList, skill.name];
+    }
+    save({
+      enable: cfg.enable,
+      enabled: enabledList,
+      disabled: [...disabledSet],
+    });
+  };
+
+  const columns: Column<SkillInfo>[] = [
+    {
+      key: "name",
+      header: "名称",
+      render: (s) => (
+        <div className="flex items-center gap-2">
+          <span className="font-medium">{s.name}</span>
+          {s.version && (
+            <span className="text-xs text-muted-foreground">v{s.version}</span>
+          )}
+        </div>
+      ),
+    },
+    {
+      key: "description",
+      header: "描述",
+      render: (s) => (
+        <span className="max-w-md truncate text-sm text-muted-foreground">
+          {s.description || "—"}
+        </span>
+      ),
+    },
+    {
+      key: "status",
+      header: "状态",
+      render: (s) => {
+        if (!s.ok) return <Badge variant="destructive">校验失败</Badge>;
+        return s.enabled ? (
+          <Badge variant="success">已启用</Badge>
+        ) : (
+          <Badge variant="secondary">已禁用</Badge>
+        );
+      },
+    },
+    {
+      key: "path",
+      header: "路径",
+      render: (s) => <code className="font-mono text-xs">{s.path}</code>,
+    },
+    {
+      key: "actions",
+      header: "操作",
+      render: (s) => (
+        <div className="flex items-center gap-3">
+          {!s.ok && s.error && (
+            <span
+              className="max-w-xs truncate text-xs text-destructive"
+              title={s.error}
+            >
+              {s.error}
+            </span>
+          )}
+          <Button
+            variant={s.enabled ? "outline" : "default"}
+            size="sm"
+            onClick={() => toggleSkill(s)}
+            disabled={saveMutation.isPending}
+          >
+            {s.enabled ? "禁用" : "启用"}
+          </Button>
+        </div>
+      ),
+    },
+  ];
+
+  return (
+    <div className="space-y-6">
+      <div className="flex items-center justify-between">
+        <div>
+          <h1 className="text-2xl font-semibold tracking-tight">技能管理</h1>
+          <p className="text-sm text-muted-foreground">
+            faskill 技能（config/chat/skills）启停与加载状态
+          </p>
+        </div>
+        <div className="flex items-center gap-4">
+          <div className="flex items-center gap-2">
+            <Switch
+              checked={enable}
+              onCheckedChange={(checked) => {
+                setEnable(checked);
+                if (data) {
+                  save({
+                    enable: checked,
+                    enabled: data.data.config.enabled,
+                    disabled: data.data.config.disabled,
+                  });
+                }
+              }}
+            />
+            <span className="text-sm">技能系统</span>
+          </div>
+          <Button
+            variant="outline"
+            onClick={() => reloadMutation.mutate()}
+            disabled={reloadMutation.isPending}
+          >
+            <RefreshCw
+              className={`mr-1 h-4 w-4 ${reloadMutation.isPending ? "animate-spin" : ""}`}
+            />
+            重新加载
+          </Button>
+        </div>
+      </div>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">启停配置</CardTitle>
+        </CardHeader>
+        <CardContent className="space-y-4">
+          <div className="grid gap-4 md:grid-cols-2">
+            <div className="space-y-2">
+              <Label>启用白名单（每行一个，留空=全部启用）</Label>
+              <Textarea
+                value={enabledText}
+                onChange={(e) => setEnabledText(e.target.value)}
+                placeholder="skill_name"
+                rows={4}
+                className="font-mono text-xs"
+              />
+            </div>
+            <div className="space-y-2">
+              <Label>禁用黑名单（每行一个，优先级高于白名单）</Label>
+              <Textarea
+                value={disabledText}
+                onChange={(e) => setDisabledText(e.target.value)}
+                placeholder="skill_name"
+                rows={4}
+                className="font-mono text-xs"
+              />
+            </div>
+          </div>
+          <div className="flex justify-end">
+            <Button
+              onClick={() =>
+                save({
+                  enable,
+                  enabled: parseList(enabledText),
+                  disabled: parseList(disabledText),
+                })
+              }
+              disabled={saveMutation.isPending}
+            >
+              <Save className="mr-1 h-4 w-4" />
+              {saveMutation.isPending ? "保存中…" : "保存配置"}
+            </Button>
+          </div>
+        </CardContent>
+      </Card>
+
+      <Card>
+        <CardHeader>
+          <CardTitle className="text-base">技能列表</CardTitle>
+        </CardHeader>
+        <CardContent>
+          <DataTable
+            columns={columns}
+            data={data?.data.skills ?? []}
+            loading={isLoading}
+            emptyText="没有发现技能（请将 SKILL.md 放入 config/chat/skills/）"
+          />
+        </CardContent>
+      </Card>
+    </div>
+  );
+}

--- a/frontend/src/pages/manage/skills.tsx
+++ b/frontend/src/pages/manage/skills.tsx
@@ -55,7 +55,9 @@ export function SkillsPage() {
       // 禁用：selected 为空时需显式列出其余全部技能；非空时从中移除
       const others = allNames.filter((n) => n !== skill.name);
       selected =
-        selected.length === 0 ? others : selected.filter((n) => n !== skill.name);
+        selected.length === 0
+          ? others
+          : selected.filter((n) => n !== skill.name);
     } else if (selected.length === 0) {
       // 全启用状态下无需修改（所有技能均已启用）
       return;

--- a/frontend/src/pages/registry.tsx
+++ b/frontend/src/pages/registry.tsx
@@ -86,4 +86,7 @@ export const registry: Record<string, ComponentType> = {
   "/manage/chat/mcp": lazy(() =>
     import("@/pages/manage/mcp").then((m) => ({ default: m.McpPage })),
   ),
+  "/manage/chat/skills": lazy(() =>
+    import("@/pages/manage/skills").then((m) => ({ default: m.SkillsPage })),
+  ),
 };

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.6.8"
+version = "1.7.0"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "AGPL-3.0-or-later"
@@ -16,6 +16,7 @@ dependencies = [
     "amrita-sense>=0.4.2",
     "async-lru>=2.0.5",
     "bcrypt>=4.3.0",
+    "faskill[amrita]>=0.2.0",
     "fastmcp>=2.14.1",
     "importlib>=1.0.4",
     "jinja2>=3.1.6",

--- a/pyproject.toml
+++ b/pyproject.toml
@@ -1,6 +1,6 @@
 [project]
 name = "amrita"
-version = "1.6.7.1"
+version = "1.6.8"
 description = "A powerful Agent bot powered by NoneBot2"
 readme = "README.md"
 license = "AGPL-3.0-or-later"

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "1.6.8"
+version = "1.7.0"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },

--- a/uv.lock
+++ b/uv.lock
@@ -249,7 +249,7 @@ wheels = [
 
 [[package]]
 name = "amrita"
-version = "1.6.7.1"
+version = "1.6.8"
 source = { editable = "." }
 dependencies = [
     { name = "aiofiles" },
@@ -262,6 +262,7 @@ dependencies = [
     { name = "amrita-sense" },
     { name = "async-lru" },
     { name = "bcrypt" },
+    { name = "faskill", extra = ["amrita"] },
     { name = "fastmcp" },
     { name = "importlib" },
     { name = "jinja2" },
@@ -305,6 +306,7 @@ requires-dist = [
     { name = "amrita-sense", specifier = ">=0.4.2" },
     { name = "async-lru", specifier = ">=2.0.5" },
     { name = "bcrypt", specifier = ">=4.3.0" },
+    { name = "faskill", extras = ["amrita"], specifier = ">=0.2.0" },
     { name = "fastmcp", specifier = ">=2.14.1" },
     { name = "importlib", specifier = ">=1.0.4" },
     { name = "jinja2", specifier = ">=3.1.6" },
@@ -948,6 +950,25 @@ dependencies = [
 sdist = { url = "https://files.pythonhosted.org/packages/50/79/66800aadf48771f6b62f7eb014e352e5d06856655206165d775e675a02c9/exceptiongroup-1.3.1.tar.gz", hash = "sha256:8b412432c6055b0b7d14c310000ae93352ed6754f70fa8f7c34141f91c4e3219", size = 30371, upload-time = "2025-11-21T23:01:54.787Z" }
 wheels = [
     { url = "https://files.pythonhosted.org/packages/8a/0e/97c33bf5009bdbac74fd2beace167cab3f978feb69cc36f1ef79360d6c4e/exceptiongroup-1.3.1-py3-none-any.whl", hash = "sha256:a7a39a3bd276781e98394987d3a5701d0c4edffb633bb7a5144577f82c773598", size = 16740, upload-time = "2025-11-21T23:01:53.443Z" },
+]
+
+[[package]]
+name = "faskill"
+version = "0.2.0"
+source = { registry = "https://pypi.org/simple" }
+dependencies = [
+    { name = "aiofiles" },
+    { name = "aiologic" },
+    { name = "pyyaml" },
+]
+sdist = { url = "https://files.pythonhosted.org/packages/a4/ec/39708fe82c470b0106a3aa5239fcec8780c2272ba2c628ccd93566942816/faskill-0.2.0.tar.gz", hash = "sha256:ac37fcd75a7498342f9e5696fc4cda2d8ef806629bd90e451c866c3ca2d6114e", size = 120610, upload-time = "2026-08-16T14:18:57.266Z" }
+wheels = [
+    { url = "https://files.pythonhosted.org/packages/4b/a8/29c1ed2d3a5f48b5e77e6d3bbba4316a940c03ded9e27f3dfff2a88b36d7/faskill-0.2.0-py3-none-any.whl", hash = "sha256:199e00b2f2619a139fe05e6b62cba40dd5c343b7c254f1eecce3b8ac224c247a", size = 63063, upload-time = "2026-08-16T14:18:56.259Z" },
+]
+
+[package.optional-dependencies]
+amrita = [
+    { name = "amrita-core" },
 ]
 
 [[package]]


### PR DESCRIPTION
## Summary by Sourcery

Integrate configurable faskill skills into chat while standardizing disk-backed model presets and strengthening WebUI/WebSocket management behavior.

New Features:
- Add configurable faskill skill discovery, invocation, progressive script-tool activation, and skill-trigger notifications to chat sessions.
- Add WebUI skill management for listing validation status, enabling or disabling skills, and reloading the skill directory.
- Expose secure model API-key status handling and preserve existing keys when editing models without changing them.

Bug Fixes:
- Prevent skill tools from mutating the global tool registry by providing session-specific tool managers.
- Improve WebSocket security and reliability with Origin validation, periodic token checks, and responsive batched log replay.
- Ensure missing or deleted model selections recover to an available disk-backed preset.

Enhancements:
- Modernize model presets so all presets, including default, are stored and managed uniformly on disk, with automatic initialization for empty preset directories.
- Integrate enabled skill descriptions into generated system prompts and support automatic skill reloads when the skills directory changes.

Build:
- Add the faskill Amrita integration dependency and bump the project version to 1.7.0.